### PR TITLE
fix connected rtt bug(the calc place is behind of the getting)

### DIFF
--- a/mars/comm/socket/tcpclient_fsm.cc
+++ b/mars/comm/socket/tcpclient_fsm.cc
@@ -251,10 +251,10 @@ void TcpClientFSM::AfterConnectSelect(const SocketSelect& _sel, XLogger& _log) {
     }
     
     if (0 == error_ && _sel.Write_FD_ISSET(sock_)){
-        xinfo2(TSF"connected Rtt:%_, ", Rtt()) >> _log;
         end_connecttime_ = gettickcount();
         last_status_ = status_;
         status_ = EReadWrite;
+        xinfo2(TSF"connected Rtt:%_, ", Rtt()) >> _log;
         _OnConnected(Rtt());
         return;
     }


### PR DESCRIPTION
The log of connected rtt time is negative, I found the src code and change the place of log print.
