### PR TITLE
修复当发生错误时, 设置UI操作的crash错误: 使之在主线程进行.

### DIFF
--- a/samples/iOS/iOSDemo/iOSDemo/TopicViewController.m
+++ b/samples/iOS/iOSDemo/iOSDemo/TopicViewController.m
@@ -58,7 +58,9 @@
 -(int)notifyUIWithResponse:(NSData*)responseData {
     SendMessageResponse *sendMsgResponse = [SendMessageResponse parseFromData:responseData];
     
-    [_recvContentField setText:sendMsgResponse.errMsg];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [_recvContentField setText:sendMsgResponse.errMsg];
+    });
     
     return sendMsgResponse.errCode == 0 ? 0 : -1;
 }


### PR DESCRIPTION
![crashofmars](https://cloud.githubusercontent.com/assets/14869903/21578096/9d6ee516-cfae-11e6-9153-36b029d5c3b8.png)
