### PR TITLE
修复AppDelegate中未设置window的警告

### DIFF
--- a/samples/iOS/iOSDemoXlog/iOSDemo/AppDelegate.h
+++ b/samples/iOS/iOSDemoXlog/iOSDemo/AppDelegate.h
@@ -22,6 +22,7 @@
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
+@property (nonatomic, strong) UIWindow *window;
 
 @end
 


### PR DESCRIPTION
修复控制台的警告日志： The app delegate must implement the window property if it wants to use a main storyboard file.

修复后控制台仅打印xlog的控制台日志，避免出现误导信息。