### PR TITLE
fix LongLinkConnectMonitor::__OnSignalActive

### DIFF
--- a/mars/stn/src/longlink_connect_monitor.cc
+++ b/mars/stn/src/longlink_connect_monitor.cc
@@ -200,7 +200,9 @@ void LongLinkConnectMonitor::__OnSignalForeground(bool _isForeground) {
 }
 
 void LongLinkConnectMonitor::__OnSignalActive(bool _isactive) {
-    __AutoIntervalConnect();
+    if (_isactive) {
+        __AutoIntervalConnect();
+    }
 }
 
 void LongLinkConnectMonitor::__OnLongLinkStatuChanged(LongLink::TLongLinkStatus _status) {


### PR DESCRIPTION
prevent re-connect when application push to background