### PR TITLE
Support split xlog file

### DIFF
--- a/mars/log/appender.h
+++ b/mars/log/appender.h
@@ -23,6 +23,7 @@
 
 #include <string>
 #include <vector>
+#include <stdint.h>
 
 enum TAppenderMode
 {
@@ -40,6 +41,13 @@ bool appender_getfilepath_from_timespan(int _timespan, const char* _prefix, std:
 bool appender_get_current_log_path(char* _log_path, unsigned int _len);
 bool appender_get_current_log_cache_path(char* _logPath, unsigned int _len);
 void appender_set_console_log(bool _is_open);
+
+/*
+ * By default, all logs will write to one file everyday. You can split logs to multi-file by changing max_file_size.
+ * 
+ * @param _max_byte_size    Max byte size of single log file, default is 0, meaning do not split.
+ */
+void appender_set_max_file_size(uint64_t _max_byte_size);
 
 
 #endif /* APPENDER_H_ */

--- a/mars/log/src/appender.cc
+++ b/mars/log/src/appender.cc
@@ -363,6 +363,7 @@ static void __move_old_files(const std::string& _src_path, const std::string& _d
     
     struct timeval tv;
     gettimeofday(&tv, NULL);
+    char logfilepath[1024] = {0};
     
     boost::filesystem::directory_iterator end_iter;
     for (boost::filesystem::directory_iterator iter(path); iter != end_iter; ++iter) {
@@ -371,7 +372,6 @@ static void __move_old_files(const std::string& _src_path, const std::string& _d
             continue;
         }
         
-        char logfilepath[1024] = {0};
         __make_logfilename(tv, _dest_path, sg_logfileprefix.c_str(), LOG_EXT, logfilepath , 1024);
         
         if (!__append_file(iter->path().string(), logfilepath)) {
@@ -379,6 +379,7 @@ static void __move_old_files(const std::string& _src_path, const std::string& _d
         }
         
         boost::filesystem::remove(iter->path());
+        memset(logfilepath, 0, sizeof(logfilepath));
     }
 }
 

--- a/mars/log/src/appender.cc
+++ b/mars/log/src/appender.cc
@@ -104,6 +104,8 @@ static bool sg_consolelog_open = true;
 static bool sg_consolelog_open = false;
 #endif
 
+static uint64_t sg_max_file_size = 0; // 0, will not split log file.
+
 static void __async_log_thread();
 static Thread sg_thread_async(&__async_log_thread);
 
@@ -134,18 +136,117 @@ class ScopeErrno {
 
 }
 
-static void __make_logfilename(const timeval& _tv, const std::string& _logdir, const char* _prefix, const std::string& _fileext, char* _filepath, unsigned int _len) {
+static std::string __make_logfilenameprefix(const timeval& _tv, const char* _prefix) {
     time_t sec = _tv.tv_sec;
     tm tcur = *localtime((const time_t*)&sec);
-
-    std::string logfilepath = _logdir;
-    logfilepath += "/";
-    logfilepath += _prefix;
+    
     char temp [64] = {0};
     snprintf(temp, 64, "_%d%02d%02d", 1900 + tcur.tm_year, 1 + tcur.tm_mon, tcur.tm_mday);
-    logfilepath += temp;
+    
+    std::string filenameprefix = _prefix;
+    filenameprefix += temp;
+    
+    return filenameprefix;
+}
+
+static void __get_filenames_by_prefix(const std::string& _logdir, const std::string& _fileprefix, const std::string& _fileext, std::vector<std::string>& _filename_vec) {
+    
+    boost::filesystem::path path(_logdir);
+    if (!boost::filesystem::is_directory(path)) {
+        return;
+    }
+    
+    boost::filesystem::directory_iterator end_iter;
+    std::string filename;
+    
+    for (boost::filesystem::directory_iterator iter(path); iter != end_iter; ++iter) {
+        if (boost::filesystem::is_regular_file(iter->status())) {
+            filename = iter->path().filename().string();
+            if (strutil::StartsWith(filename, _fileprefix) && strutil::EndsWith(filename, _fileext)) {
+                _filename_vec.push_back(filename);
+            }
+        }
+    }
+}
+
+static void __get_filepaths_from_timeval(const timeval& _tv, const std::string& _logdir, const char* _prefix, const std::string& _fileext, std::vector<std::string>& _filepath_vec) {
+    
+    std::string fileprefix = __make_logfilenameprefix(_tv, _prefix);
+    std::vector<std::string> filename_vec;
+    __get_filenames_by_prefix(_logdir, fileprefix, _fileext, filename_vec);
+    
+    for (std::vector<std::string>::iterator iter = filename_vec.begin(); iter != filename_vec.end(); ++ iter) {
+        _filepath_vec.push_back(_logdir + "/" + (*iter));
+    }
+}
+
+static bool __string_compare_greater(const std::string& s1, const std::string& s2) {
+    if (s1.length() == s2.length()) {
+        return s1 > s2;
+    }
+    return s1.length() > s2.length();
+}
+
+static long __get_next_fileindex(const std::string& _fileprefix, const std::string& _fileext) {
+    
+    std::vector<std::string> filename_vec;
+    __get_filenames_by_prefix(sg_logdir, _fileprefix, _fileext, filename_vec);
+    if (!sg_cache_logdir.empty()) {
+        __get_filenames_by_prefix(sg_cache_logdir, _fileprefix, _fileext, filename_vec);
+    }
+    
+    long index = 0; // long is enought to hold all indexes in one day.
+    if (filename_vec.empty()) {
+        return index;
+    }
+    // high -> low
+    std::sort(filename_vec.begin(), filename_vec.end(), __string_compare_greater);
+    std::string last_filename = *(filename_vec.begin());
+    std::size_t ext_pos = last_filename.rfind("." + _fileext);
+    std::size_t index_len = ext_pos - _fileprefix.length();
+    if (index_len > 0) {
+        std::string index_str = last_filename.substr(_fileprefix.length(), index_len);
+        if (strutil::StartsWith(index_str, "_")) {
+            index_str = index_str.substr(1);
+        }
+        index = atol(index_str.c_str());
+    }
+    
+    uint64_t filesize = 0;
+    std::string logfilepath = sg_logdir + "/" + last_filename;
+    if (boost::filesystem::exists(logfilepath)) {
+        filesize += boost::filesystem::file_size(logfilepath);
+    }
+    if (!sg_cache_logdir.empty()) {
+        logfilepath = sg_cache_logdir + "/" + last_filename;
+        if (boost::filesystem::exists(logfilepath)) {
+            filesize += boost::filesystem::file_size(logfilepath);
+        }
+    }
+    return (filesize > sg_max_file_size) ? index + 1 : index;
+}
+
+static void __make_logfilename(const timeval& _tv, const std::string& _logdir, const char* _prefix, const std::string& _fileext, char* _filepath, unsigned int _len) {
+    
+    long index = 0;
+    std::string logfilenameprefix = __make_logfilenameprefix(_tv, _prefix);
+    if (sg_max_file_size > 0) {
+        index = __get_next_fileindex(logfilenameprefix, _fileext);
+    }
+    
+    std::string logfilepath = _logdir;
+    logfilepath += "/";
+    logfilepath += logfilenameprefix;
+    
+    if (index > 0) {
+        char temp[24] = {0};
+        snprintf(temp, 24, "_%ld", index);
+        logfilepath += temp;
+    }
+    
     logfilepath += ".";
     logfilepath += _fileext;
+    
     strncpy(_filepath, logfilepath.c_str(), _len - 1);
     _filepath[_len - 1] = '\0';
 }
@@ -260,16 +361,20 @@ static void __move_old_files(const std::string& _src_path, const std::string& _d
     
     ScopedLock lock_file(sg_mutex_log_file);
     
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    
     boost::filesystem::directory_iterator end_iter;
     for (boost::filesystem::directory_iterator iter(path); iter != end_iter; ++iter) {
         
-        if (!strutil::StartsWith(iter->path().string(), _nameprefix) || !strutil::EndsWith(iter->path().string(), LOG_EXT)) {
+        if (!strutil::StartsWith(iter->path().filename().string(), _nameprefix) || !strutil::EndsWith(iter->path().string(), LOG_EXT)) {
             continue;
         }
         
-        std::string des_file_name = _dest_path + "/" + iter->path().filename().string();
+        char logfilepath[1024] = {0};
+        __make_logfilename(tv, _dest_path, sg_logfileprefix.c_str(), LOG_EXT, logfilepath , 1024);
         
-        if (!__append_file(iter->path().string(), des_file_name)) {
+        if (!__append_file(iter->path().string(), logfilepath)) {
             break;
         }
         
@@ -888,6 +993,10 @@ void appender_set_console_log(bool _is_open) {
     sg_consolelog_open = _is_open;
 }
 
+void appender_set_max_file_size(uint64_t _max_byte_size) {
+    sg_max_file_size = _max_byte_size;
+}
+
 void appender_setExtraMSg(const char* _msg, unsigned int _len) {
     sg_log_extra_msg = std::string(_msg, _len);
 }
@@ -899,19 +1008,9 @@ bool appender_getfilepath_from_timespan(int _timespan, const char* _prefix, std:
     gettimeofday(&tv, NULL);
     tv.tv_sec -= _timespan * (24 * 60 * 60);
 
-    char log_path[2048] = { 0 };
-    __make_logfilename(tv, sg_logdir, _prefix, LOG_EXT, log_path, sizeof(log_path));
-
-    _filepath_vec.push_back(log_path);
-
-    if (sg_cache_logdir.empty()) {
-        return true;
+    __get_filepaths_from_timeval(tv, sg_logdir, _prefix, LOG_EXT, _filepath_vec);
+    if (!sg_cache_logdir.empty()) {
+        __get_filepaths_from_timeval(tv, sg_cache_logdir, _prefix, LOG_EXT, _filepath_vec);
     }
-
-    memset(log_path, 0, sizeof(log_path));
-    __make_logfilename(tv, sg_cache_logdir, _prefix, LOG_EXT, log_path, sizeof(log_path));
-
-    _filepath_vec.push_back(log_path);
-
     return true;
 }


### PR DESCRIPTION
1. Added method `appender_set_max_file_size(uint64_t)` to split xlog file.
2. Fixed bug: can't move old xlog file from cache to log dir.