### PR TITLE
解决arm64-v8a架构下alarm导致崩溃的问题

### DIFF
--- a/mars/comm/jni/OnAlarm.inl
+++ b/mars/comm/jni/OnAlarm.inl
@@ -10,6 +10,6 @@
 
 extern "C" JNIEXPORT void JNICALL Java_com_tencent_mars_comm_Alarm_onAlarm(JNIEnv *, jclass, jlong id)
 {
-    xdebug2(TSF"BroadcastMessage seq:%_", (long long)id);
-    MessageQueue::BroadcastMessage(MessageQueue::GetDefMessageQueue(), MessageQueue::Message(KALARM_MESSAGETITLE, (long long)id, 0));
+    xdebug2(TSF"BroadcastMessage seq:%_", (int64_t)id);
+    MessageQueue::BroadcastMessage(MessageQueue::GetDefMessageQueue(), MessageQueue::Message(KALARM_MESSAGETITLE, (int64_t)id, 0));
 }


### PR DESCRIPTION
arm64-v8a架构下long long和int64_t类型不一样，导致Alarm.onAlarm中的boost:any_cast<int64_t>(_message.body1)引起崩溃