### PR TITLE
解决android平台上mars::stn message queue线程可能卡死的问题

### DIFF
--- a/mars/comm/jni/ifaddrs.c
+++ b/mars/comm/jni/ifaddrs.c
@@ -147,11 +147,6 @@ static struct nlmsghdr *getNetlinkResponse(int p_socket, int *p_size, int *p_don
             struct nlmsghdr *l_hdr;
             for(l_hdr = (struct nlmsghdr *)l_buffer; NLMSG_OK(l_hdr, (unsigned int)l_read); l_hdr = (struct nlmsghdr *)NLMSG_NEXT(l_hdr, l_read))
             {
-                if((pid_t)l_hdr->nlmsg_pid != l_pid || (int)l_hdr->nlmsg_seq != p_socket)
-                {
-                    continue;
-                }
-                
                 if(l_hdr->nlmsg_type == NLMSG_DONE)
                 {
                     *p_done = 1;
@@ -555,11 +550,6 @@ static int interpretLinks(int p_socket, NetlinkList *p_netlinkList, struct ifadd
         struct nlmsghdr *l_hdr;
         for(l_hdr = p_netlinkList->m_data; NLMSG_OK(l_hdr, l_nlsize); l_hdr = NLMSG_NEXT(l_hdr, l_nlsize))
         {
-            if((pid_t)l_hdr->nlmsg_pid != l_pid || (int)l_hdr->nlmsg_seq != p_socket)
-            {
-                continue;
-            }
-            
             if(l_hdr->nlmsg_type == NLMSG_DONE)
             {
                 break;
@@ -587,11 +577,6 @@ static int interpretAddrs(int p_socket, NetlinkList *p_netlinkList, struct ifadd
         struct nlmsghdr *l_hdr;
         for(l_hdr = p_netlinkList->m_data; NLMSG_OK(l_hdr, l_nlsize); l_hdr = NLMSG_NEXT(l_hdr, l_nlsize))
         {
-            if((pid_t)l_hdr->nlmsg_pid != l_pid || (int)l_hdr->nlmsg_seq != p_socket)
-            {
-                continue;
-            }
-            
             if(l_hdr->nlmsg_type == NLMSG_DONE)
             {
                 break;


### PR DESCRIPTION
如果其他so库也创建了netlink socket，并且没有关闭，则这里的nlmsg_pid可能就不是process id。这种情况下
getNetlinkResponse虽然已经收到了NLMSG_DONE消息，但是仍然不会退出for循环，继续调用netlink_recv时就会
被 recvmsg 调用阻塞

下面是linux手册上对于这个问题的解释:
nlmsg_pid shows the origin of the message.  Note that there isn't a 1:1 relationship
between nlmsg_pid and the PID of the process if the message
originated from a netlink socket.  See the ADDRESS FORMATS section
for further information.

http://www.man7.org/linux/man-pages/man7/netlink.7.html