### PR TITLE
mmaped_file全局对象改成引用，避免全局释放时析构时机不当导致crash

### DIFF
--- a/mars/log/src/appender.cc
+++ b/mars/log/src/appender.cc
@@ -114,7 +114,7 @@ static const long kMaxLogAliveTime = 10 * 24 * 60 * 60;	// 10 days in second
 
 static std::string sg_log_extra_msg;
 
-static boost::iostreams::mapped_file sg_mmmap_file;
+static boost::iostreams::mapped_file& sg_mmmap_file = *(new boost::iostreams::mapped_file);
 
 namespace {
 class ScopeErrno {


### PR DESCRIPTION
[https://github.com/Tencent/mars/issues/456](issue 456)