### PR TITLE
prevent null pointer access when multiple threads call `appender_close`

### DIFF
--- a/mars/log/src/appender.cc
+++ b/mars/log/src/appender.cc
@@ -981,7 +981,9 @@ void appender_close() {
 
         CloseMmapFile(sg_mmmap_file);
     } else {
+      if (sg_log_buff!=nullptr){
         delete[] (char*)((sg_log_buff->GetData()).Ptr());
+      }
     }
 
     delete sg_log_buff;


### PR DESCRIPTION
## lldb reproduce:
```
br s -f appender.cc -l 907
* thread #2, stop reason = breakpoint 3.1
    frame #0: 0x0000000100033a37 lib_log-63ad328ff2a75d6b`::appender_close() at appender.cc:908 [opt]
   905
   906
   907      ScopedLock buffer_lock(sg_mutex_buffer_async);
-> 908      if (sg_mmmap_file.is_open()) {
   909          if (!sg_mmmap_file.operator !()) memset(sg_mmmap_file.data(), 0, kBufferBlockLength);
   910
   911                  CloseMmapFile(sg_mmmap_file);
Target 0: (lib_log-63ad328ff2a75d6b) stopped.
test tests::test_xlog_close ... Process 70681 stopped
* thread #6, stop reason = breakpoint 3.1
    frame #0: 0x0000000100033a37 lib_log-63ad328ff2a75d6b`::appender_close() at appender.cc:908 [opt]
   905
   906
   907      ScopedLock buffer_lock(sg_mutex_buffer_async);
-> 908      if (sg_mmmap_file.is_open()) {
   909          if (!sg_mmmap_file.operator !()) memset(sg_mmmap_file.data(), 0, kBufferBlockLength);
   910
   911                  CloseMmapFile(sg_mmmap_file);

(lldb) p sg_log_buff
(LogBuffer *) $20 = 0x0000000000000000
(lldb) n
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 27 filtered out

Process 70681 stopped
* thread #6, stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #0: 0x0000000100041768 lib_log-63ad328ff2a75d6b`PtrBuffer::Ptr(this=0x0000000000000000) at ptrbuffer.cc:124 [opt]
   121  }
   122
   123  void*  PtrBuffer::Ptr() {
-> 124      return parray_;
   125  }
   126
   127  const void*  PtrBuffer::Ptr() const {
Target 0: (lib_log-63ad328ff2a75d6b) stopped.
```


<img width="1015" alt="image" src="https://user-images.githubusercontent.com/302560/52055894-a2066f00-259b-11e9-8eac-06a4ff303cc0.png">

1. block at the top cannot prevent multiple thread reach block at the bottom at the same time.
2. once one thread went through the block at the bottom, `sg_log_buff` will be null. Other threads which reach L984 will trigger a segment fault.

