### PR TITLE
Verify noop packets with taskId and cmdId.

### DIFF
--- a/mars/libraries/mars_android_sdk/jni/longlink_packer.cc
+++ b/mars/libraries/mars_android_sdk/jni/longlink_packer.cc
@@ -124,9 +124,9 @@ uint32_t (*longlink_noop_cmdid)()
     return NOOP_CMDID;
 };
 
-bool  (*longlink_noop_isresp)(uint32_t _taskid, uint32_t _cmdid, uint32_t _recv_seq, const AutoBuffer& _body, const AutoBuffer& _extend)
-= [](uint32_t _taskid, uint32_t _cmdid, uint32_t _recv_seq, const AutoBuffer& _body, const AutoBuffer& _extend) {
-    return Task::kNoopTaskID == _taskid && NOOP_CMDID == _cmdid;
+bool  (*longlink_noop_isresp)(uint32_t _cmdid, uint32_t _recv_seq, const AutoBuffer& _body, const AutoBuffer& _extend)
+= [](uint32_t _cmdid, uint32_t _recv_seq, const AutoBuffer& _body, const AutoBuffer& _extend) {
+    return Task::kNoopTaskID == _recv_seq && NOOP_CMDID == _cmdid;
 };
 
 uint32_t (*signal_keep_cmdid)()

--- a/mars/libraries/mars_android_sdk/jni/longlink_packer.cc.rewriteme
+++ b/mars/libraries/mars_android_sdk/jni/longlink_packer.cc.rewriteme
@@ -124,9 +124,9 @@ uint32_t (*longlink_noop_cmdid)()
     return NOOP_CMDID;
 };
 
-bool  (*longlink_noop_isresp)(uint32_t _taskid, uint32_t _cmdid, uint32_t _recv_seq, const AutoBuffer& _body, const AutoBuffer& _extend)
-= [](uint32_t _taskid, uint32_t _cmdid, uint32_t _recv_seq, const AutoBuffer& _body, const AutoBuffer& _extend) {
-    return Task::kNoopTaskID == _taskid && NOOP_CMDID == _cmdid;
+bool  (*longlink_noop_isresp)(uint32_t _cmdid, uint32_t _recv_seq, const AutoBuffer& _body, const AutoBuffer& _extend)
+= [](uint32_t _cmdid, uint32_t _recv_seq, const AutoBuffer& _body, const AutoBuffer& _extend) {
+    return Task::kNoopTaskID == _recv_seq && NOOP_CMDID == _cmdid;
 };
 
 uint32_t (*signal_keep_cmdid)()

--- a/mars/libraries/mars_android_sdk/jni/longlink_packer.h
+++ b/mars/libraries/mars_android_sdk/jni/longlink_packer.h
@@ -71,7 +71,7 @@ extern int  (*longlink_unpack)(const AutoBuffer& _packed, uint32_t& _cmdid, uint
 
 //heartbeat signal to keep longlink network alive
 extern uint32_t (*longlink_noop_cmdid)();
-extern bool  (*longlink_noop_isresp)(uint32_t _taskid, uint32_t _cmdid, uint32_t _recv_seq, const AutoBuffer& _body, const AutoBuffer& _extend);
+extern bool  (*longlink_noop_isresp)(uint32_t _cmdid, uint32_t _recv_seq, const AutoBuffer& _body, const AutoBuffer& _extend);
 extern uint32_t (*signal_keep_cmdid)();
 extern void (*longlink_noop_req_body)(AutoBuffer& _body, AutoBuffer& _extend);
 extern void (*longlink_noop_resp_body)(const AutoBuffer& _body, const AutoBuffer& _extend);

--- a/mars/sdt/src/activecheck/tcpchecker.cc
+++ b/mars/sdt/src/activecheck/tcpchecker.cc
@@ -129,7 +129,7 @@ bool TcpChecker::__NoopResp(const AutoBuffer& _packed, uint32_t& _cmdid, uint32_
     AutoBuffer extension;
 	int unpackret = longlink_unpack(_packed, _cmdid, _seq, _package_len, _body, extension, NULL);
 	if (unpackret == LONGLINK_UNPACK_OK) {
-        if (longlink_noop_isresp(Task::kNoopTaskID, _cmdid, _seq, _body, extension)) {
+        if (longlink_noop_isresp(_cmdid, _seq, _body, extension)) {
 			longlink_noop_resp_body(_body, extension);
 			return true;
 		}

--- a/mars/stn/proto/longlink_packer.cc
+++ b/mars/stn/proto/longlink_packer.cc
@@ -124,9 +124,9 @@ uint32_t (*longlink_noop_cmdid)()
     return NOOP_CMDID;
 };
 
-bool  (*longlink_noop_isresp)(uint32_t _taskid, uint32_t _cmdid, uint32_t _recv_seq, const AutoBuffer& _body, const AutoBuffer& _extend)
-= [](uint32_t _taskid, uint32_t _cmdid, uint32_t _recv_seq, const AutoBuffer& _body, const AutoBuffer& _extend) {
-    return Task::kNoopTaskID == _taskid && NOOP_CMDID == _cmdid;
+bool  (*longlink_noop_isresp)(uint32_t _cmdid, uint32_t _recv_seq, const AutoBuffer& _body, const AutoBuffer& _extend)
+= [](uint32_t _cmdid, uint32_t _recv_seq, const AutoBuffer& _body, const AutoBuffer& _extend) {
+    return Task::kNoopTaskID == _recv_seq && NOOP_CMDID == _cmdid;
 };
 
 uint32_t (*signal_keep_cmdid)()

--- a/mars/stn/proto/longlink_packer.h
+++ b/mars/stn/proto/longlink_packer.h
@@ -71,7 +71,7 @@ extern int  (*longlink_unpack)(const AutoBuffer& _packed, uint32_t& _cmdid, uint
 
 //heartbeat signal to keep longlink network alive
 extern uint32_t (*longlink_noop_cmdid)();
-extern bool  (*longlink_noop_isresp)(uint32_t _taskid, uint32_t _cmdid, uint32_t _recv_seq, const AutoBuffer& _body, const AutoBuffer& _extend);
+extern bool  (*longlink_noop_isresp)(uint32_t _cmdid, uint32_t _recv_seq, const AutoBuffer& _body, const AutoBuffer& _extend);
 extern uint32_t (*signal_keep_cmdid)();
 extern void (*longlink_noop_req_body)(AutoBuffer& _body, AutoBuffer& _extend);
 extern void (*longlink_noop_resp_body)(const AutoBuffer& _body, const AutoBuffer& _extend);

--- a/mars/stn/src/longlink.cc
+++ b/mars/stn/src/longlink.cc
@@ -111,7 +111,7 @@ class LongLinkConnectObserver : public MComplexConnect {
             return false;
         }
 
-        if (!longlink_noop_isresp(taskid, cmdid, taskid, bufferbody, extension)) {
+        if (!longlink_noop_isresp(cmdid, taskid, bufferbody, extension)) {
             xwarn2(TSF"index:%_, sock:%_, %_, ret:%_, cmdid:%_, taskid:%_, pack_len:%_, recv_len:%_", _index, _socket, _addr.url(), ret, cmdid, taskid, pack_len, _buffer_recv.Length());
         }
 
@@ -311,7 +311,7 @@ bool LongLink::__NoopResp(uint32_t _cmdid, uint32_t _taskid, AutoBuffer& _buf, A
         }
     }
     
-    if (longlink_noop_isresp(Task::kNoopTaskID, _cmdid, _taskid, _buf, _extension)) {
+    if (longlink_noop_isresp(_cmdid, _taskid, _buf, _extension)) {
         longlink_noop_resp_body(_buf, _extension);
         xinfo2(TSF"end noop");
         is_noop = true;

--- a/mars/stn/src/longlink_speed_test.cc
+++ b/mars/stn/src/longlink_speed_test.cc
@@ -220,7 +220,7 @@ int LongLinkSpeedTestItem::__HandleSpeedTestResp() {
 
             resp_ab_.Reset();
             return kLongLinkSpeedTestOOB;
-        } else if (longlink_noop_isresp(Task::kNoopTaskID, anCmdID, anSeq, body, extension)) {
+        } else if (longlink_noop_isresp(anCmdID, anSeq, body, extension)) {
             return kLongLinkSpeedTestSuc;
         } else {
             xassert2(false);


### PR DESCRIPTION
Signed-off-by: zhaoya <zhaoya188@qq.com>

The original problem was just using cmdId only inside `longlink_noop_isresp`.