### PR TITLE
fix xlog build will have MarsReachability symbole duplicate problem

### DIFF
--- a/mars/comm/objc/ThreadOperationQueue.mm
+++ b/mars/comm/objc/ThreadOperationQueue.mm
@@ -1,3 +1,15 @@
+// Tencent is pleased to support the open source community by making Mars available.
+// Copyright (C) 2016 THL A29 Limited, a Tencent company. All rights reserved.
+
+// Licensed under the MIT License (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://opensource.org/licenses/MIT
+
+// Unless required by applicable law or agreed to in writing, software distributed under the License is
+// distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
 //
 //  ThreadOperationQueue.mm
 //  MicroMessenger

--- a/mars/comm/objc/objc_console.mm
+++ b/mars/comm/objc/objc_console.mm
@@ -1,4 +1,16 @@
 
+// Tencent is pleased to support the open source community by making Mars available.
+// Copyright (C) 2016 THL A29 Limited, a Tencent company. All rights reserved.
+
+// Licensed under the MIT License (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://opensource.org/licenses/MIT
+
+// Unless required by applicable law or agreed to in writing, software distributed under the License is
+// distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
 #import <Foundation/Foundation.h>
 #include "comm/xlogger/xlogger.h"
 #include "comm/xlogger/loginfo_extract.h"

--- a/mars/comm/objc/objc_console.mm
+++ b/mars/comm/objc/objc_console.mm
@@ -1,0 +1,31 @@
+
+#import <Foundation/Foundation.h>
+#include "comm/xlogger/xlogger.h"
+#include "comm/xlogger/loginfo_extract.h"
+#import "comm/objc/scope_autoreleasepool.h"
+
+void ConsoleLog(const XLoggerInfo* _info, const char* _log)
+{
+    SCOPE_POOL();
+
+    if (NULL==_info || NULL==_log) return;
+    
+    static const char* levelStrings[] = {
+        "V",
+        "D",  // debug
+        "I",  // info
+        "W",  // warn
+        "E",  // error
+        "F"  // fatal
+    };
+    
+    char strFuncName[128]  = {0};
+    ExtractFunctionName(_info->func_name, strFuncName, sizeof(strFuncName));
+    
+    const char* file_name = ExtractFileName(_info->filename);
+    
+    char log[16 * 1024] = {0};
+    snprintf(log, sizeof(log), "[%s][%s][%s, %s, %d][%s", levelStrings[_info->level], NULL == _info->tag ? "" : _info->tag, file_name, strFuncName, _info->line, _log);
+    
+    NSLog(@"%@", [NSString stringWithUTF8String:log]);
+}

--- a/mars/comm/objc/objc_timer.mm
+++ b/mars/comm/objc/objc_timer.mm
@@ -1,3 +1,14 @@
+// Tencent is pleased to support the open source community by making Mars available.
+// Copyright (C) 2016 THL A29 Limited, a Tencent company. All rights reserved.
+
+// Licensed under the MIT License (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://opensource.org/licenses/MIT
+
+// Unless required by applicable law or agreed to in writing, software distributed under the License is
+// distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
 //
 //  objc_timer.cpp
 //  MicroMessenger

--- a/mars/comm/objc/platform_comm.mm
+++ b/mars/comm/objc/platform_comm.mm
@@ -177,32 +177,6 @@ unsigned int getSignal(bool isWifi){
     return (unsigned int)0;
 }
 
-void ConsoleLog(const XLoggerInfo* _info, const char* _log)
-{
-    SCOPE_POOL();
-
-    if (NULL==_info || NULL==_log) return;
-    
-    static const char* levelStrings[] = {
-        "V",
-        "D",  // debug
-        "I",  // info
-        "W",  // warn
-        "E",  // error
-        "F"  // fatal
-    };
-    
-    char strFuncName[128]  = {0};
-    ExtractFunctionName(_info->func_name, strFuncName, sizeof(strFuncName));
-    
-    const char* file_name = ExtractFileName(_info->filename);
-    
-    char log[16 * 1024] = {0};
-    snprintf(log, sizeof(log), "[%s][%s][%s, %s, %d][%s", levelStrings[_info->level], NULL == _info->tag ? "" : _info->tag, file_name, strFuncName, _info->line, _log);
-    
-    NSLog(@"%@", [NSString stringWithUTF8String:log]);
-}
-
 bool isNetworkConnected()
 {
    SCOPE_POOL(); 

--- a/mars/comm/objc/platform_comm.mm
+++ b/mars/comm/objc/platform_comm.mm
@@ -1,3 +1,15 @@
+// Tencent is pleased to support the open source community by making Mars available.
+// Copyright (C) 2016 THL A29 Limited, a Tencent company. All rights reserved.
+
+// Licensed under the MIT License (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://opensource.org/licenses/MIT
+
+// Unless required by applicable law or agreed to in writing, software distributed under the License is
+// distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
 /**
  * created on : 2012-11-28
  * author : yerungui

--- a/mars/comm/objc/scope_autoreleasepool.mm
+++ b/mars/comm/objc/scope_autoreleasepool.mm
@@ -1,3 +1,14 @@
+// Tencent is pleased to support the open source community by making Mars available.
+// Copyright (C) 2016 THL A29 Limited, a Tencent company. All rights reserved.
+
+// Licensed under the MIT License (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://opensource.org/licenses/MIT
+
+// Unless required by applicable law or agreed to in writing, software distributed under the License is
+// distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
 //
 //  scope_autoreleasepool.cpp
 //  MicroMessenger

--- a/mars/comm/objc/xlogger_threadinfo.mm
+++ b/mars/comm/objc/xlogger_threadinfo.mm
@@ -1,3 +1,14 @@
+// Tencent is pleased to support the open source community by making Mars available.
+// Copyright (C) 2016 THL A29 Limited, a Tencent company. All rights reserved.
+
+// Licensed under the MIT License (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://opensource.org/licenses/MIT
+
+// Unless required by applicable law or agreed to in writing, software distributed under the License is
+// distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
 //
 //  xloggr_threadinfo.m
 //  MicroMessenger

--- a/mars/comm/verinfo.h
+++ b/mars/comm/verinfo.h
@@ -2,10 +2,10 @@
 #ifndef Mars_verinfo_h
 #define Mars_verinfo_h
 
-#define MARS_REVISION "0a65602"
-#define MARS_PATH "rb/2019-JUN"
+#define MARS_REVISION "810e303c"
+#define MARS_PATH "feature/fix_platform_comm"
 #define MARS_URL ""
-#define MARS_BUILD_TIME "2019-08-28 15:47:49"
-#define MARS_TAG "test"
+#define MARS_BUILD_TIME "2019-12-23 14:48:13"
+#define MARS_TAG ""
 
 #endif


### PR DESCRIPTION
1. extract Console_Log function from platform_comm.mm file
2. move Console_Log function to objc_console file so that xlog build does not include platform