### PR TITLE
suppress 'has no synbols' static linking warnings

### DIFF
--- a/mars/mars_utils.py
+++ b/mars/mars_utils.py
@@ -82,7 +82,7 @@ def libtool_libs(src_libs, dst_lib):
         src_lib_str = '%s %s'%(src_lib_str, l)
 
     print(src_lib_str)
-    ret = os.system('libtool -static -o %s %s' %(dst_lib, src_lib_str))
+    ret = os.system('libtool -static -no_warning_for_no_symbols -o %s %s' %(dst_lib, src_lib_str))
     if ret != 0:
         print('!!!!!!!!!!!libtool %s fail!!!!!!!!!!!!!!!' %(dst_lib))
         return False


### PR DESCRIPTION
During linking phase on mac OS, there are lots of 'has no synbols' warnings. The warnings  indicate that those object files contained no operational code.  For more details, please refer to https://stackoverflow.com/questions/4929255/building-static-libraries-on-mac-using-cmake-and-gcc#answer-4953904

cmake_build/OSX/Darwin.out/libcomm.a cmake_build/OSX/Darwin.out/libxlog.a cmake_build/OSX/Darwin.out/libapp.a cmake_build/OSX/Darwin.out/libbaseevent.a cmake_build/OSX/Darwin.out/libmars-boost.a cmake_build/OSX/Darwin.out/libstn.a cmake_build/OSX/Darwin.out/libsdt.a openssl/openssl_lib_osx/libssl.a openssl/openssl_lib_osx/libcrypto.a
/Library/Developer/CommandLineTools/usr/bin/libtool: file: cmake_build/OSX/Darwin.out/libmars-boost.a(gregorian_types.cpp.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/libtool: file: cmake_build/OSX/Darwin.out/libmars-boost.a(posix_time_types.cpp.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/libtool: file: cmake_build/OSX/Darwin.out/libmars-boost.a(windows_file_codecvt.cpp.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/libtool: file: cmake_build/OSX/Darwin.out/libmars-boost.a(sp_collector.cpp.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/libtool: file: cmake_build/OSX/Darwin.out/libmars-boost.a(sp_debug_hooks.cpp.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/libtool: file: cmake_build/OSX/Darwin.out/libmars-boost.a(future.cpp.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/libtool: file: openssl/openssl_lib_osx/libssl.a(ssl_utst.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/libtool: file: openssl/openssl_lib_osx/libssl.a(t1_trce.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/libtool: file: openssl/openssl_lib_osx/libcrypto.a(async_null.o) has no symbols