### PR TITLE
fix error

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,18 +324,24 @@ python build_windows.py
 Initialize Xlog when your app starts. Remember to use an exclusive folder to save the log files, no other files are acceptable in the folder since they would be removed by the cleansing function in Xlog automatically.
 
 ```cpp
-std::string logPath = ""; //use your log path
-std::string pubKey = ""; //use you pubkey for log encrypt
-
 // init xlog
-#if DEBUG
-xlogger_SetLevel(kLevelDebug);
-appender_set_console_log(true);
+#if _DEBUG
+	xlogger_SetLevel(kLevelDebug);
+	appender_set_console_log(true);
+	extern std::function<void(char* _log)> g_console_log_fun;
+	g_console_log_fun = [](char* _log) {
+		::OutputDebugStringA(_log);
+	};
 #else
-xlogger_SetLevel(kLevelInfo);
-appender_set_console_log(false);
+	xlogger_SetLevel(kLevelInfo);
+	appender_set_console_log(false);
 #endif
-appender_open(kAppednerAsync, logPath.c_str(), "Test", 0, pubKey.c_str());
+
+	XLogConfig config;
+	config.logdir_ = "Log"; //use your log path
+	config.nameprefix_ = "Sample";
+	config.pub_key_ = ""; //use you pubkey for log encrypt
+	appender_open(config);
 ```
 
 Uninitialized xlog before your app exits
@@ -386,7 +392,10 @@ Firstly, you should call the setCalBack interface, and secondly, the Mars.init. 
 If you want to destroy STN or exit App:
 
 ```cpp
-mars::baseevent::OnDestroy();
+void Cleanup()
+{
+    mars::baseevent::OnDestroy();
+}
 ```
 
 ## Support
@@ -726,18 +735,24 @@ python build_windows.py
 在程序启动加载 Xlog 后紧接着初始化 Xlog。但要注意保存 log 的目录请使用单独的目录，不要存放任何其他文件防止被 xlog 自动清理功能误删。
 
 ```cpp
-std::string logPath = ""; //use your log path
-std::string pubKey = ""; //use you pubkey for log encrypt
-
 // init xlog
-#if DEBUG
-xlogger_SetLevel(kLevelDebug);
-appender_set_console_log(true);
+#if _DEBUG
+	xlogger_SetLevel(kLevelDebug);
+	appender_set_console_log(true);
+	extern std::function<void(char* _log)> g_console_log_fun;
+	g_console_log_fun = [](char* _log) {
+		::OutputDebugStringA(_log);
+	};
 #else
-xlogger_SetLevel(kLevelInfo);
-appender_set_console_log(false);
+	xlogger_SetLevel(kLevelInfo);
+	appender_set_console_log(false);
 #endif
-appender_open(kAppednerAsync, logPath.c_str(), "Test", 0,  pubKey.c_str());
+
+	XLogConfig config;
+	config.logdir_ = "Log"; //use your log path
+	config.nameprefix_ = "Sample";
+	config.pub_key_ = ""; //use you pubkey for log encrypt
+	appender_open(config);
 ```
 
 在程序退出前反初始化 Xlog
@@ -755,10 +770,12 @@ void setShortLinkDebugIP(const std::string& _ip, unsigned short _port)
 {
 	mars::stn::SetShortlinkSvrAddr(_port, _ip);
 }
+
 void setShortLinkPort(unsigned short _port)
 {
 	mars::stn::SetShortlinkSvrAddr(_port, "");
 }
+
 void setLongLinkAddress(const std::string& _ip, unsigned short _port, const std::string& _debug_ip)
 {
 	vector<uint16_t> ports;
@@ -788,7 +805,15 @@ void Init()
 需要释放 STN 或者退出程序时:
 
 ```cpp
-mars::baseevent::OnDestroy();
+void Cleanup()
+{
+    mars::baseevent::OnDestroy();
+}
+```
+
+**注意：有关WeakNetworkLogic的相关代码为mars的扩展,使用的时候建议开发者将其注视掉不然会导致一些错误**
+```cpp
+WeakNetworkLogic::Singleton::Instance()
 ```
 
 ## Support

--- a/mars/comm/http.cc
+++ b/mars/comm/http.cc
@@ -177,7 +177,7 @@ bool RequestLine::FromString(const std::string& _requestline) {
 
     if (strVer.size() < 3) {
 //        xerror2(TSF"requestline:%_, strver:%_", _requestline.c_str(), str.c_str());
-        xassert2(false, "requestline:%s, strver:%s", _requestline.c_str(), str.c_str());
+        xassert2(false, TSF"requestline:%s, strver:%s", _requestline.c_str(), str.c_str());
         return false;
     }
 

--- a/mars/comm/strutil.cc
+++ b/mars/comm/strutil.cc
@@ -324,7 +324,7 @@ private:
 // find substring (case insensitive)
 size_t ci_find_substr(const std::string& str, const std::string& sub, size_t pos){
     const std::locale& loc = std::locale();
-    typename std::string::const_iterator it = std::search(str.begin() + pos, str.end(),
+    auto it = std::search(str.begin() + pos, str.end(),
                                                 sub.begin(), sub.end(), my_equal<typename std::string::value_type>(loc));
     
     if (it != str.end()) return it - str.begin();

--- a/mars/log/src/appender.cc
+++ b/mars/log/src/appender.cc
@@ -924,19 +924,20 @@ void appender_open(const XLogConfig& _config) {
     snprintf(mmap_file_path, sizeof(mmap_file_path), "%s/%s.mmap3", sg_cache_logdir.empty() ? _config.logdir_.c_str() : sg_cache_logdir.c_str(), _config.nameprefix_.c_str());
 
     bool use_mmap = false;
+	bool use_compress = true;
     if (OpenMmapFile(mmap_file_path, kBufferBlockLength, sg_mmmap_file))  {
         if (_config.compress_mode_ == kZstd){
-            sg_log_buff = new LogZstdBuffer(sg_mmmap_file.data(), kBufferBlockLength, true, _config.pub_key_.c_str(), _config.compress_level_);
+            sg_log_buff = new LogZstdBuffer(sg_mmmap_file.data(), kBufferBlockLength, use_compress, _config.pub_key_.c_str(), _config.compress_level_);
         }else {
-            sg_log_buff = new LogZlibBuffer(sg_mmmap_file.data(), kBufferBlockLength, true, _config.pub_key_.c_str());
+            sg_log_buff = new LogZlibBuffer(sg_mmmap_file.data(), kBufferBlockLength, use_compress, _config.pub_key_.c_str());
         }
         use_mmap = true;
     } else {
         char* buffer = new char[kBufferBlockLength];
         if (_config.compress_mode_ == kZstd){
-            sg_log_buff = new LogZstdBuffer(buffer, kBufferBlockLength, true, _config.pub_key_.c_str(), _config.compress_level_);
+            sg_log_buff = new LogZstdBuffer(buffer, kBufferBlockLength, use_compress, _config.pub_key_.c_str(), _config.compress_level_);
         } else {
-            sg_log_buff = new LogZlibBuffer(buffer, kBufferBlockLength, true, _config.pub_key_.c_str());
+            sg_log_buff = new LogZlibBuffer(buffer, kBufferBlockLength, use_compress, _config.pub_key_.c_str());
         }
         use_mmap = false;
     }

--- a/mars/log/src/appender.cc
+++ b/mars/log/src/appender.cc
@@ -924,7 +924,7 @@ void appender_open(const XLogConfig& _config) {
     snprintf(mmap_file_path, sizeof(mmap_file_path), "%s/%s.mmap3", sg_cache_logdir.empty() ? _config.logdir_.c_str() : sg_cache_logdir.c_str(), _config.nameprefix_.c_str());
 
     bool use_mmap = false;
-	bool use_compress = true;
+    bool use_compress = true;
     if (OpenMmapFile(mmap_file_path, kBufferBlockLength, sg_mmmap_file))  {
         if (_config.compress_mode_ == kZstd){
             sg_log_buff = new LogZstdBuffer(sg_mmmap_file.data(), kBufferBlockLength, use_compress, _config.pub_key_.c_str(), _config.compress_level_);

--- a/mars/log/src/formater.cc
+++ b/mars/log/src/formater.cc
@@ -84,16 +84,17 @@ void log_formater(const XLoggerInfo* _info, const char* _logbody, PtrBuffer& _lo
         if (0 != _info->timeval.tv_sec) {
             time_t sec = _info->timeval.tv_sec;
             tm tm = *localtime((const time_t*)&sec);
-            std::string gmt = std::to_string(tm.tm_gmtoff / 360);
             
 #ifdef ANDROID
+			std::string gmt = std::to_string(tm.tm_gmtoff / 360);
             snprintf(temp_time, sizeof(temp_time), "%d-%02d-%02d +%.3s %02d:%02d:%02d.%.3ld", 1900 + tm.tm_year, 1 + tm.tm_mon, tm.tm_mday,
                      gmt.c_str(), tm.tm_hour, tm.tm_min, tm.tm_sec, _info->timeval.tv_usec / 1000);
 #elif _WIN32
             snprintf(temp_time, sizeof(temp_time), "%d-%02d-%02d +%.3s %02d:%02d:%02d.%.3d", 1900 + tm.tm_year, 1 + tm.tm_mon, tm.tm_mday,
                      (-_timezone) / 3600.0, tm.tm_hour, tm.tm_min, tm.tm_sec, _info->timeval.tv_usec / 1000);
 #else
-            snprintf(temp_time, sizeof(temp_time), "%d-%02d-%02d +%.3s %02d:%02d:%02d.%.3d", 1900 + tm.tm_year, 1 + tm.tm_mon, tm.tm_mday,
+			std::string gmt = std::to_string(tm.tm_gmtoff / 360);
+			snprintf(temp_time, sizeof(temp_time), "%d-%02d-%02d +%.3s %02d:%02d:%02d.%.3d", 1900 + tm.tm_year, 1 + tm.tm_mon, tm.tm_mday,
                      gmt.c_str(), tm.tm_hour, tm.tm_min, tm.tm_sec, _info->timeval.tv_usec / 1000);
 #endif
         }

--- a/mars/log/src/formater.cc
+++ b/mars/log/src/formater.cc
@@ -90,7 +90,7 @@ void log_formater(const XLoggerInfo* _info, const char* _logbody, PtrBuffer& _lo
             snprintf(temp_time, sizeof(temp_time), "%d-%02d-%02d +%.3s %02d:%02d:%02d.%.3ld", 1900 + tm.tm_year, 1 + tm.tm_mon, tm.tm_mday,
                      gmt.c_str(), tm.tm_hour, tm.tm_min, tm.tm_sec, _info->timeval.tv_usec / 1000);
 #elif _WIN32
-            snprintf(temp_time, sizeof(temp_time), "%d-%02d-%02d +%.3s %02d:%02d:%02d.%.3d", 1900 + tm.tm_year, 1 + tm.tm_mon, tm.tm_mday,
+            snprintf(temp_time, sizeof(temp_time), "%d-%02d-%02d +%.1f %02d:%02d:%02d.%.3d", 1900 + tm.tm_year, 1 + tm.tm_mon, tm.tm_mday,
                      (-_timezone) / 3600.0, tm.tm_hour, tm.tm_min, tm.tm_sec, _info->timeval.tv_usec / 1000);
 #else
             std::string gmt = std::to_string(tm.tm_gmtoff / 360);

--- a/mars/log/src/formater.cc
+++ b/mars/log/src/formater.cc
@@ -86,15 +86,15 @@ void log_formater(const XLoggerInfo* _info, const char* _logbody, PtrBuffer& _lo
             tm tm = *localtime((const time_t*)&sec);
             
 #ifdef ANDROID
-			std::string gmt = std::to_string(tm.tm_gmtoff / 360);
+            std::string gmt = std::to_string(tm.tm_gmtoff / 360);
             snprintf(temp_time, sizeof(temp_time), "%d-%02d-%02d +%.3s %02d:%02d:%02d.%.3ld", 1900 + tm.tm_year, 1 + tm.tm_mon, tm.tm_mday,
                      gmt.c_str(), tm.tm_hour, tm.tm_min, tm.tm_sec, _info->timeval.tv_usec / 1000);
 #elif _WIN32
             snprintf(temp_time, sizeof(temp_time), "%d-%02d-%02d +%.3s %02d:%02d:%02d.%.3d", 1900 + tm.tm_year, 1 + tm.tm_mon, tm.tm_mday,
                      (-_timezone) / 3600.0, tm.tm_hour, tm.tm_min, tm.tm_sec, _info->timeval.tv_usec / 1000);
 #else
-			std::string gmt = std::to_string(tm.tm_gmtoff / 360);
-			snprintf(temp_time, sizeof(temp_time), "%d-%02d-%02d +%.3s %02d:%02d:%02d.%.3d", 1900 + tm.tm_year, 1 + tm.tm_mon, tm.tm_mday,
+            std::string gmt = std::to_string(tm.tm_gmtoff / 360);
+            snprintf(temp_time, sizeof(temp_time), "%d-%02d-%02d +%.3s %02d:%02d:%02d.%.3d", 1900 + tm.tm_year, 1 + tm.tm_mon, tm.tm_mday,
                      gmt.c_str(), tm.tm_hour, tm.tm_min, tm.tm_sec, _info->timeval.tv_usec / 1000);
 #endif
         }

--- a/mars/stn/src/longlink.cc
+++ b/mars/stn/src/longlink.cc
@@ -747,6 +747,7 @@ void LongLink::__RunReadWrite(SOCKET _sock, ErrCmdType& _errtype, int& _errcode,
 
                     if (nsent_datas.size() >= kMaxLongLinkNWriteDataLength) {
                         xgroup2_define(nwrite_log);
+                        xinfo2(TSF"info nwrite: ") >> nwrite_log;
                         ShowLongLinkNWriteDataList(nsent_datas, nwrite_log);
                     }
                     
@@ -859,7 +860,6 @@ End:
         xinfo2(TSF", info nwrite:%_ ", nwrite_size) >> close_log;
         ShowLongLinkNWriteDataList(nsent_datas, close_log);
     }
-    nsent_datas.clear();
     
     if (nread_size > 0 && _errtype != kEctNetMsgXP && _errcode != kEctNetMsgXPHandleBufferErr) {
         xinfo2(TSF", info nread:%_ ", nread_size) >> close_log;

--- a/mars/stn/src/longlink.cc
+++ b/mars/stn/src/longlink.cc
@@ -724,7 +724,7 @@ void LongLink::__RunReadWrite(SOCKET _sock, ErrCmdType& _errtype, int& _errcode,
                 if (0 == it->second->Pos() && OnSend) OnSend(it->first.taskid);
                 
                 if ((size_t)writelen >= it->second->PosLength()) {
-                    xinfo2(TSF"sub send taskid:%_, cmdid:%_, %_, len(S:%_, %_/%_), ", it->first.taskid, it->first.cmdid, it->first.cgi, it->second->PosLength(), it->second->PosLength(), it->second->Length()) >> xlog_group;
+                    xinfo2(TSF"sub send taskid:%_, cmdid:%_, cgi:%_, len(S:%_, %_/%_), ", it->first.taskid, it->first.cmdid, it->first.cgi, it->second->PosLength(), it->second->PosLength(), it->second->Length()) >> xlog_group;
                     writelen -= it->second->PosLength();
                     if (!it->first.send_only) { sent_taskids[it->first.taskid].task = it->first; }
                     
@@ -733,7 +733,7 @@ void LongLink::__RunReadWrite(SOCKET _sock, ErrCmdType& _errtype, int& _errcode,
                     
                     it = lstsenddata_.erase(it);
                 } else {
-                    xinfo2(TSF"sub send taskid:%_, cmdid:%_, %_, len(S:%_, %_/%_), ", it->first.taskid, it->first.cmdid, it->first.cgi, writelen, it->second->PosLength(), it->second->Length()) >> xlog_group;
+                    xinfo2(TSF"sub send taskid:%_, cmdid:%_, cgi:%_, len(S:%_, %_/%_), ", it->first.taskid, it->first.cmdid, it->first.cgi, writelen, it->second->PosLength(), it->second->Length()) >> xlog_group;
                     it->second->Seek(writelen, AutoBuffer::ESeekCur);
                     writelen = 0;
                 }

--- a/mars/stn/src/longlink.cc
+++ b/mars/stn/src/longlink.cc
@@ -746,7 +746,8 @@ void LongLink::__RunReadWrite(SOCKET _sock, ErrCmdType& _errtype, int& _errcode,
                     nsent_datas.push_back(nwrite);
 
                     if (nsent_datas.size() >= kMaxLongLinkNWriteDataLength) {
-                        ShowLongLinkNWriteData(nsent_datas, xlog_group);
+                        xgroup2_define(nwrite_log);
+                        ShowLongLinkNWriteDataList(nsent_datas, nwrite_log);
                     }
                     
                     it = lstsenddata_.erase(it);
@@ -856,7 +857,7 @@ End:
     int nread_size = socket_nread(_sock);
     if (nwrite_size > 0) {
         xinfo2(TSF", info nwrite:%_ ", nwrite_size) >> close_log;
-        ShowLongLinkNWriteData(nsent_datas, close_log);
+        ShowLongLinkNWriteDataList(nsent_datas, close_log);
     }
     nsent_datas.clear();
     

--- a/mars/stn/src/longlink_task_manager.cc
+++ b/mars/stn/src/longlink_task_manager.cc
@@ -841,7 +841,7 @@ bool LongLinkTaskManager::AddLongLink(const LonglinkConfig& _config) {
         return false;
     }
     
-    ScopedLock lock(meta_mutex_);
+//    ScopedLock lock(meta_mutex_);
     longlink_id ++;
     if (longlink_id == INT_MAX) {
         longlink_id = 1;

--- a/mars/stn/src/longlink_task_manager.cc
+++ b/mars/stn/src/longlink_task_manager.cc
@@ -867,7 +867,7 @@ bool LongLinkTaskManager::AddLongLink(const LonglinkConfig& _config) {
 
 void LongLinkTaskManager::ReleaseLongLink(const std::string _name) {
     xinfo_function(TSF"release longlink:%_", _name);
-    ScopedLock lock(meta_mutex_);
+//    ScopedLock lock(meta_mutex_);
     auto longlink = GetLongLink(_name);
     if(longlink == nullptr)
         return;
@@ -889,7 +889,7 @@ void LongLinkTaskManager::ReleaseLongLink(const std::string _name) {
     longlink_metas_.erase(_name);
     longlink->Channel()->SignalConnection.disconnect_all_slots();
     longlink->Monitor()->DisconnectAllSlot();
-    lock.unlock();
+//    lock.unlock();
     {
     // MessageQueue::AsyncInvoke([&,longlink] () {
 //        longlink->Channel()->OnSend = NULL;

--- a/mars/stn/src/longlink_task_manager.cc
+++ b/mars/stn/src/longlink_task_manager.cc
@@ -64,7 +64,6 @@ LongLinkTaskManager::LongLinkTaskManager(NetSource& _netsource, ActiveLogic& _ac
 #ifdef ANDROID
     , wakeup_lock_(new WakeUpLock())
 #endif
-    , meta_mutex_(true)
 {
     xinfo_function(TSF"handler:(%_,%_)", asyncreg_.Get().queue, asyncreg_.Get().seq);
 }

--- a/mars/stn/src/net_core.cc
+++ b/mars/stn/src/net_core.cc
@@ -774,12 +774,12 @@ std::shared_ptr<LongLink> NetCore::CreateLongLink(const LonglinkConfig& _config)
 
     auto longlink = longlink_task_manager_->GetLongLink(_config.name);
     if(!longlink) {
-	    xassert2(false, "get longlink nullptr with name:%s", _config.name.c_str());
+	    xassert2(false, TSF"get longlink nullptr with name:%s", _config.name.c_str());
 	    return nullptr;
     }
     auto longlink_channel = longlink->Channel();
     if(!longlink_channel) {
-        xassert2(false, "get longlink nullptr with name:%s", _config.name.c_str());
+        xassert2(false, TSF"get longlink nullptr with name:%s", _config.name.c_str());
         return nullptr;
     }
     

--- a/mars/stn/stn.h
+++ b/mars/stn/stn.h
@@ -251,30 +251,29 @@ extern bool MakesureAuthed(const std::string& _host, const std::string& _user_id
 extern void TrafficData(ssize_t _send, ssize_t _recv);
         
 //底层询问上层该host对应的ip列表 
-extern std::vector<std::string> OnNewDns(const std::string& host);
+extern std::vector<std::string> OnNewDns(const std::string& _host);
 //网络层收到push消息回调 
 extern void OnPush(const std::string& _channel_id, uint32_t _cmdid, uint32_t _taskid, const AutoBuffer& _body, const AutoBuffer& _extend);
 //底层获取task要发送的数据 
-extern bool Req2Buf(uint32_t taskid, void* const user_context, const std::string& _user_id, AutoBuffer& outbuffer, AutoBuffer& extend, int& error_code, const int channel_select, const std::string& host);
+extern bool Req2Buf(uint32_t taskid, void* const user_context, const std::string& _user_id, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select, const std::string& _host);
 //底层回包返回给上层解析 
-extern int Buf2Resp(uint32_t taskid, void* const user_context, const std::string& _user_id, const AutoBuffer& inbuffer, const AutoBuffer& extend, int& error_code, const int channel_select);
+extern int Buf2Resp(uint32_t taskid, void* const user_context, const std::string& _user_id, const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select);
 //任务执行结束 
-extern int  OnTaskEnd(uint32_t taskid, void* const user_context, const std::string& _user_id, int error_type, int error_code);
+extern int OnTaskEnd(uint32_t taskid, void* const user_context, const std::string& _user_id, int error_type, int error_code);
 
 //上报网络连接状态 
-extern void ReportConnectStatus(int status, int longlink_status);
+extern void ReportConnectStatus(int _status, int _longlink_status);
         
 extern void OnLongLinkNetworkError(ErrCmdType _err_type, int _err_code, const std::string& _ip, uint16_t _port);
 extern void OnShortLinkNetworkError(ErrCmdType _err_type, int _err_code, const std::string& _ip, const std::string& _host, uint16_t _port);
     
 extern void OnLongLinkStatusChange(int _status);
 //长连信令校验 ECHECK_NOW = 0, ECHECK_NEVER = 1, ECHECK_NEXT = 2
-extern int  GetLonglinkIdentifyCheckBuffer(const std::string& _channel_id, AutoBuffer& identify_buffer, AutoBuffer& buffer_hash, int32_t& cmdid);
+extern int GetLonglinkIdentifyCheckBuffer(const std::string& _channel_id, AutoBuffer& _identify_buffer, AutoBuffer& _buffer_hash, int32_t& _cmdid);
 //长连信令校验回包 
-extern bool OnLonglinkIdentifyResponse(const std::string& _channel_id, const AutoBuffer& response_buffer, const AutoBuffer& identify_buffer_hash);
+extern bool OnLonglinkIdentifyResponse(const std::string& _channel_id, const AutoBuffer& _response_buffer, const AutoBuffer& _identify_buffer_hash);
 
 extern void RequestSync();
-//验证是否已登录
 
 //底层询问上层http网络检查的域名列表 
 extern void RequestNetCheckShortLinkHosts(std::vector<std::string>& _hostlist);

--- a/mars/stn/stn_callback_bridge.cc
+++ b/mars/stn/stn_callback_bridge.cc
@@ -233,7 +233,7 @@ void TrafficData(ssize_t _send, ssize_t _recv) {
 };
 
 //底层询问上层该host对应的ip列表
-std::vector<std::string> OnNewDns(const std::string& host) {
+std::vector<std::string> OnNewDns(const std::string& _host) {
     xassert2(sg_callback_bridge != NULL);
     return sg_callback_bridge->OnNewDns(host);
 };
@@ -244,25 +244,25 @@ void OnPush(const std::string& _channel_id, uint32_t _cmdid, uint32_t _taskid, c
     sg_callback_bridge->OnPush(_channel_id, _cmdid, _taskid, _body, _extend);
 };
 //底层获取task要发送的数据
-bool Req2Buf(uint32_t taskid,  void* const user_context, const std::string& _user_id, AutoBuffer& outbuffer, AutoBuffer& extend, int& error_code, const int channel_select, const std::string& host) {
+bool Req2Buf(uint32_t taskid,  void* const user_context, const std::string& _user_id, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select, const std::string& _host) {
     xassert2(sg_callback_bridge != NULL);
-    return sg_callback_bridge->Req2Buf(taskid, user_context, _user_id, outbuffer, extend, error_code, channel_select, host);
+    return sg_callback_bridge->Req2Buf(taskid, user_context, _user_id, _outbuffer, _extend, _error_code, _channel_select, _host);
 };
 //底层回包返回给上层解析
-int Buf2Resp(uint32_t taskid, void* const user_context, const std::string& _user_id, const AutoBuffer& inbuffer, const AutoBuffer& extend, int& error_code, const int channel_select) {
+int Buf2Resp(uint32_t taskid, void* const user_context, const std::string& _user_id, const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select) {
     xassert2(sg_callback_bridge != NULL);
-    return sg_callback_bridge->Buf2Resp(taskid, user_context, _user_id, inbuffer, extend, error_code, channel_select);
+    return sg_callback_bridge->Buf2Resp(taskid, user_context, _user_id, _inbuffer, _extend, _error_code, _channel_select);
 };
 //任务执行结束
-int  OnTaskEnd(uint32_t taskid, void* const user_context, const std::string& _user_id, int error_type, int error_code) {
+int  OnTaskEnd(uint32_t taskid, void* const user_context, const std::string& _user_id, int _error_type, int _error_code) {
     xassert2(sg_callback_bridge != NULL);
-    return sg_callback_bridge->OnTaskEnd(taskid, user_context, _user_id, error_type, error_code);
+    return sg_callback_bridge->OnTaskEnd(taskid, user_context, _user_id, _error_type, _error_code);
 };
 
 //上报网络连接状态
-void ReportConnectStatus(int status, int longlink_status) {
+void ReportConnectStatus(int _status, int _longlink_status) {
     xassert2(sg_callback_bridge != NULL);
-    sg_callback_bridge->ReportConnectStatus(status, longlink_status);
+    sg_callback_bridge->ReportConnectStatus(_status, _longlink_status);
 };
 
 void OnLongLinkStatusChange(int _status) {
@@ -281,14 +281,14 @@ void OnShortLinkNetworkError(ErrCmdType _err_type, int _err_code, const std::str
     sg_callback_bridge->OnShortLinkNetworkError(_err_type, _err_code, _ip, _host, _port);
 };
 //长连信令校验 ECHECK_NOW = 0, ECHECK_NEVER = 1, ECHECK_NEXT = 2
-int  GetLonglinkIdentifyCheckBuffer(const std::string& _channel_id, AutoBuffer& identify_buffer, AutoBuffer& buffer_hash, int32_t& cmdid) {
+int  GetLonglinkIdentifyCheckBuffer(const std::string& _channel_id, AutoBuffer& _identify_buffer, AutoBuffer& _buffer_hash, int32_t& _cmdid) {
     xassert2(sg_callback_bridge != NULL);
-    return sg_callback_bridge->GetLonglinkIdentifyCheckBuffer(_channel_id, identify_buffer, buffer_hash, cmdid);
+    return sg_callback_bridge->GetLonglinkIdentifyCheckBuffer(_channel_id, _identify_buffer, _buffer_hash, _cmdid);
 };
 //长连信令校验回包
-bool OnLonglinkIdentifyResponse(const std::string& _channel_id, const AutoBuffer& response_buffer, const AutoBuffer& identify_buffer_hash) {
+bool OnLonglinkIdentifyResponse(const std::string& _channel_id, const AutoBuffer& _response_buffer, const AutoBuffer& _identify_buffer_hash) {
     xassert2(sg_callback_bridge != NULL);
-    return sg_callback_bridge->OnLonglinkIdentifyResponse(_channel_id, response_buffer, identify_buffer_hash);
+    return sg_callback_bridge->OnLonglinkIdentifyResponse(_channel_id, _response_buffer, _identify_buffer_hash);
 };
 
 void RequestSync() {

--- a/mars/stn/stn_callback_bridge.cc
+++ b/mars/stn/stn_callback_bridge.cc
@@ -220,7 +220,7 @@ void StnCallbackBridge::ReportTaskLimited(int _check_type, const Task& _task, un
 void StnCallbackBridge::ReportDnsProfile(const DnsProfile& _dns_profile) {
 }
 
-//callback functions
+// callback functions
 bool MakesureAuthed(const std::string& _host, const std::string& _user_id) {
     xassert2(sg_callback_bridge != NULL);
     return sg_callback_bridge->MakesureAuthed(_host, _user_id);
@@ -232,34 +232,34 @@ void TrafficData(ssize_t _send, ssize_t _recv) {
     return sg_callback_bridge->TrafficData(_send, _recv);
 };
 
-//底层询问上层该host对应的ip列表
+// 底层询问上层该host对应的ip列表
 std::vector<std::string> OnNewDns(const std::string& _host) {
     xassert2(sg_callback_bridge != NULL);
     return sg_callback_bridge->OnNewDns(_host);
 };
 
-//网络层收到push消息回调
+// 网络层收到push消息回调
 void OnPush(const std::string& _channel_id, uint32_t _cmdid, uint32_t _taskid, const AutoBuffer& _body, const AutoBuffer& _extend) {
     xassert2(sg_callback_bridge != NULL);
     sg_callback_bridge->OnPush(_channel_id, _cmdid, _taskid, _body, _extend);
 };
-//底层获取task要发送的数据
+// 底层获取task要发送的数据
 bool Req2Buf(uint32_t taskid,  void* const user_context, const std::string& _user_id, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select, const std::string& _host) {
     xassert2(sg_callback_bridge != NULL);
     return sg_callback_bridge->Req2Buf(taskid, user_context, _user_id, _outbuffer, _extend, _error_code, _channel_select, _host);
 };
-//底层回包返回给上层解析
+// 底层回包返回给上层解析
 int Buf2Resp(uint32_t taskid, void* const user_context, const std::string& _user_id, const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select) {
     xassert2(sg_callback_bridge != NULL);
     return sg_callback_bridge->Buf2Resp(taskid, user_context, _user_id, _inbuffer, _extend, _error_code, _channel_select);
 };
-//任务执行结束
+// 任务执行结束
 int  OnTaskEnd(uint32_t taskid, void* const user_context, const std::string& _user_id, int _error_type, int _error_code) {
     xassert2(sg_callback_bridge != NULL);
     return sg_callback_bridge->OnTaskEnd(taskid, user_context, _user_id, _error_type, _error_code);
 };
 
-//上报网络连接状态
+// 上报网络连接状态
 void ReportConnectStatus(int _status, int _longlink_status) {
     xassert2(sg_callback_bridge != NULL);
     sg_callback_bridge->ReportConnectStatus(_status, _longlink_status);
@@ -281,12 +281,12 @@ void OnShortLinkNetworkError(ErrCmdType _err_type, int _err_code, const std::str
     SignalOnShortLinkNetworkError(_err_type, _err_code, _ip, _host, _port);
     sg_callback_bridge->OnShortLinkNetworkError(_err_type, _err_code, _ip, _host, _port);
 };
-//长连信令校验 ECHECK_NOW = 0, ECHECK_NEVER = 1, ECHECK_NEXT = 2
+// 长连信令校验 ECHECK_NOW = 0, ECHECK_NEVER = 1, ECHECK_NEXT = 2
 int GetLonglinkIdentifyCheckBuffer(const std::string& _channel_id, AutoBuffer& _identify_buffer, AutoBuffer& _buffer_hash, int32_t& _cmdid) {
     xassert2(sg_callback_bridge != NULL);
     return sg_callback_bridge->GetLonglinkIdentifyCheckBuffer(_channel_id, _identify_buffer, _buffer_hash, _cmdid);
 };
-//长连信令校验回包
+// 长连信令校验回包
 bool OnLonglinkIdentifyResponse(const std::string& _channel_id, const AutoBuffer& _response_buffer, const AutoBuffer& _identify_buffer_hash) {
     xassert2(sg_callback_bridge != NULL);
     return sg_callback_bridge->OnLonglinkIdentifyResponse(_channel_id, _response_buffer, _identify_buffer_hash);

--- a/mars/stn/stn_callback_bridge.cc
+++ b/mars/stn/stn_callback_bridge.cc
@@ -235,7 +235,7 @@ void TrafficData(ssize_t _send, ssize_t _recv) {
 //底层询问上层该host对应的ip列表
 std::vector<std::string> OnNewDns(const std::string& _host) {
     xassert2(sg_callback_bridge != NULL);
-    return sg_callback_bridge->OnNewDns(host);
+    return sg_callback_bridge->OnNewDns(_host);
 };
 
 //网络层收到push消息回调

--- a/mars/stn/stn_callback_bridge.cc
+++ b/mars/stn/stn_callback_bridge.cc
@@ -269,6 +269,7 @@ void OnLongLinkStatusChange(int _status) {
     xassert2(sg_callback_bridge != NULL);
     sg_callback_bridge->OnLongLinkStatusChange(_status);
 };
+
 void OnLongLinkNetworkError(ErrCmdType _err_type, int _err_code, const std::string& _ip, uint16_t _port) {
     xassert2(sg_callback_bridge != NULL);
     SignalOnLongLinkNetworkError(_err_type, _err_code, _ip, _port);
@@ -281,7 +282,7 @@ void OnShortLinkNetworkError(ErrCmdType _err_type, int _err_code, const std::str
     sg_callback_bridge->OnShortLinkNetworkError(_err_type, _err_code, _ip, _host, _port);
 };
 //长连信令校验 ECHECK_NOW = 0, ECHECK_NEVER = 1, ECHECK_NEXT = 2
-int  GetLonglinkIdentifyCheckBuffer(const std::string& _channel_id, AutoBuffer& _identify_buffer, AutoBuffer& _buffer_hash, int32_t& _cmdid) {
+int GetLonglinkIdentifyCheckBuffer(const std::string& _channel_id, AutoBuffer& _identify_buffer, AutoBuffer& _buffer_hash, int32_t& _cmdid) {
     xassert2(sg_callback_bridge != NULL);
     return sg_callback_bridge->GetLonglinkIdentifyCheckBuffer(_channel_id, _identify_buffer, _buffer_hash, _cmdid);
 };

--- a/mars/stn/stn_callback_bridge.cc
+++ b/mars/stn/stn_callback_bridge.cc
@@ -28,8 +28,8 @@ boost::signals2::signal<void (ErrCmdType _err_type, int _err_code, const std::st
 boost::signals2::signal<void (ErrCmdType _err_type, int _err_code, const std::string& _ip, const std::string& _host, uint16_t _port)> SignalOnShortLinkNetworkError;
 
 
-void SetCallback(Callback* const callback) {
-    sg_callback = callback;
+void SetCallback(Callback* const _callback) {
+    sg_callback = _callback;
 }
 
 void SetStnCallbackBridge(StnCallbackBridge* _callback_bridge) {
@@ -61,12 +61,12 @@ void StnCallbackBridge::TrafficData(ssize_t _send, ssize_t _recv) {
 #endif
 }
 
-std::vector<std::string> StnCallbackBridge::OnNewDns(const std::string& host) {
+std::vector<std::string> StnCallbackBridge::OnNewDns(const std::string& _host) {
 #ifndef ANDROID
     xassert2(sg_callback != NULL);
-    return sg_callback->OnNewDns(host);
+    return sg_callback->OnNewDns(_host);
 #else
-    return C2Java_OnNewDns(host);
+    return C2Java_OnNewDns(_host);
 #endif
 }
 
@@ -86,16 +86,16 @@ void StnCallbackBridge::OnPush(const std::string& _channel_id,
 bool StnCallbackBridge::Req2Buf(uint32_t _taskid,
                                 void* const _user_context,
                                 const std::string& _user_id,
-                                AutoBuffer& outbuffer,
-                                AutoBuffer& extend,
-                                int& error_code,
-                                const int channel_select,
-                                const std::string& host) {
+                                AutoBuffer& _outbuffer,
+                                AutoBuffer& _extend,
+                                int& _error_code,
+                                const int _channel_select,
+                                const std::string& _host) {
 #ifndef ANDROID
     xassert2(sg_callback != NULL);
-    return sg_callback->Req2Buf(_taskid, _user_context, _user_id, outbuffer, extend, error_code, channel_select, host);
+    return sg_callback->Req2Buf(_taskid, _user_context, _user_id, _outbuffer, _extend, _error_code, _channel_select, _host);
 #else
-    return C2Java_Req2Buf(_taskid, _user_context, _user_id, outbuffer, extend, error_code, channel_select, host);
+    return C2Java_Req2Buf(_taskid, _user_context, _user_id, _outbuffer, _extend, _error_code, _channel_select, _host);
 #endif
 }
 

--- a/mars/stn/stn_callback_bridge.h
+++ b/mars/stn/stn_callback_bridge.h
@@ -27,7 +27,7 @@ class StnCallbackBridge {
 
     virtual void TrafficData(ssize_t _send, ssize_t _recv);
 
-    virtual std::vector<std::string> OnNewDns(const std::string& host);
+    virtual std::vector<std::string> OnNewDns(const std::string& _host);
     virtual void OnPush(const std::string& _channel_id,
                         uint32_t _cmdid,
                         uint32_t _taskid,
@@ -36,11 +36,11 @@ class StnCallbackBridge {
     virtual bool Req2Buf(uint32_t _taskid,
                          void* const _user_context,
                          const std::string& _user_id,
-                         AutoBuffer& outbuffer,
-                         AutoBuffer& extend,
-                         int& error_code,
-                         const int channel_select,
-                         const std::string& host);
+                         AutoBuffer& _outbuffer,
+                         AutoBuffer& _extend,
+                         int& _error_code,
+                         const int _channel_select,
+                         const std::string& _host);
     virtual int Buf2Resp(uint32_t _taskid,
                          void* const _user_context,
                          const std::string& _user_id,

--- a/mars/stn/stn_logic.cc
+++ b/mars/stn/stn_logic.cc
@@ -272,31 +272,54 @@ uint32_t (*getNoopTaskID)()
 
 // [+] Lambda syntax could apply a conversion between lambda and function pointer
 // https://stackoverflow.com/questions/18889028/a-positive-lambda-what-sorcery-is-this
-auto CreateLonglink_ext = +[](const LonglinkConfig& _config){
-    STN_WEAK_CALL(CreateLongLink(_config));
+// auto CreateLonglink_ext = +[](const LonglinkConfig& _config){
+//     STN_WEAK_CALL(CreateLongLink(_config));
+// };
+void(*CreateLonglink_ext)(const LonglinkConfig& _config)
+= [](const LonglinkConfig& _config) {
+	STN_WEAK_CALL(CreateLongLink(_config));
 };
     
-auto DestroyLonglink_ext = +[](const std::string& name){
-    STN_WEAK_CALL(DestroyLongLink(name));
+// auto DestroyLonglink_ext = +[](const std::string& name) {
+// 	STN_WEAK_CALL(DestroyLongLink(name));
+// };
+void(*DestroyLonglink_ext)(const std::string& name)
+= [](const std::string& name) {
+	STN_WEAK_CALL(DestroyLongLink(name));
 };
+
 //auto GetAllLonglink_ext = +[]()->std::vector<std::string>{
 //    std::vector<std::string> res;
 //    STN_WEAK_CALL_RETURN(GetAllLonglink(), res);
 //    return res;
 //};
 
-auto LongLinkIsConnected_ext = +[](const std::string& name)->bool{
-    bool res = false;
-    STN_WEAK_CALL_RETURN(LongLinkIsConnected_ext(name),res);
-    return res;
+// auto LongLinkIsConnected_ext = +[](const std::string& name)->bool{
+//     bool res = false;
+//     STN_WEAK_CALL_RETURN(LongLinkIsConnected_ext(name),res);
+//     return res;
+// };
+bool(*LongLinkIsConnected_ext)(const std::string& name)
+= [](const std::string& name) {
+	bool res = false;
+	STN_WEAK_CALL_RETURN(LongLinkIsConnected_ext(name), res);
+	return res;
 };
 
-auto MarkMainLonglink_ext = +[](const std::string& name){
-    STN_WEAK_CALL(MarkMainLonglink_ext(name));
+// auto MarkMainLonglink_ext = +[](const std::string& name){
+//     STN_WEAK_CALL(MarkMainLonglink_ext(name));
+// };
+void(*MarkMainLonglink_ext)(const std::string& name)
+= [](const std::string& name) {
+	STN_WEAK_CALL(MarkMainLonglink_ext(name));
 };
     
-auto MakesureLonglinkConnected_ext = +[](const std::string& name){
-    STN_WEAK_CALL(MakeSureLongLinkConnect_ext(name));
+// auto MakesureLonglinkConnected_ext = +[](const std::string& name){
+//     STN_WEAK_CALL(MakeSureLongLinkConnect_ext(name));
+// };
+void(*MakesureLonglinkConnected_ext)(const std::string& name)
+= [](const std::string& name) {
+	STN_WEAK_CALL(MakeSureLongLinkConnect_ext(name));
 };
     
 //auto KeepSignalling_ext = +[](const std::string& name){

--- a/mars/stn/stn_logic.h
+++ b/mars/stn/stn_logic.h
@@ -47,16 +47,15 @@ namespace stn{
         virtual void TrafficData(ssize_t _send, ssize_t _recv) = 0;
         
         //底层询问上层该host对应的ip列表 
-        virtual std::vector<std::string> OnNewDns(const std::string& host) = 0;
+        virtual std::vector<std::string> OnNewDns(const std::string& _host) = 0;
         //网络层收到push消息回调 
         virtual void OnPush(const std::string& _channel_id, uint32_t _cmdid, uint32_t _taskid, const AutoBuffer& _body, const AutoBuffer& _extend) = 0;
         //底层获取task要发送的数据 
-        virtual bool Req2Buf(uint32_t _taskid, void* const _user_context, const std::string& _user_id, AutoBuffer& outbuffer, AutoBuffer& extend, int& error_code, const int channel_select, const std::string& host) = 0;
+        virtual bool Req2Buf(uint32_t _taskid, void* const _user_context, const std::string& _user_id, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select, const std::string& _host) = 0;
         //底层回包返回给上层解析 
         virtual int Buf2Resp(uint32_t _taskid, void* const _user_context, const std::string& _user_id,  const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select) = 0;
         //任务执行结束 
-        virtual int  OnTaskEnd(uint32_t _taskid, void* const _user_context, const std::string& _user_id, int _error_type, int _error_code) = 0;
-
+        virtual int OnTaskEnd(uint32_t _taskid, void* const _user_context, const std::string& _user_id, int _error_type, int _error_code) = 0;
 
         //上报网络连接状态 
         virtual void ReportConnectStatus(int _status, int _longlink_status) = 0;
@@ -65,17 +64,14 @@ namespace stn{
         
         virtual void OnLongLinkStatusChange(int _status) {}
         //长连信令校验 ECHECK_NOW = 0, ECHECK_NEXT = 1, ECHECK_NEVER = 2 
-        virtual int  GetLonglinkIdentifyCheckBuffer(const std::string& _channel_id, AutoBuffer& _identify_buffer, AutoBuffer& _buffer_hash, int32_t& _cmdid) = 0;
+        virtual int GetLonglinkIdentifyCheckBuffer(const std::string& _channel_id, AutoBuffer& _identify_buffer, AutoBuffer& _buffer_hash, int32_t& _cmdid) = 0;
         //长连信令校验回包 
         virtual bool OnLonglinkIdentifyResponse(const std::string& _channel_id, const AutoBuffer& _response_buffer, const AutoBuffer& _identify_buffer_hash) = 0;
         
-        
         virtual void RequestSync() = 0;
-        
-        //验证是否已登录 
     };
 
-    void SetCallback(Callback* const callback);
+    void SetCallback(Callback* const _callback);
     
 
 //    extern void SetLonglinkSvrAddr(const std::string& host, const std::vector<uint16_t> ports);
@@ -143,13 +139,13 @@ namespace stn{
     /// these APIs are subject to change in developing
     ///
     //===----------------------------------------------------------------------===//
-    extern void (*CreateLonglink_ext)(const LonglinkConfig& _config);
-    extern void (*DestroyLonglink_ext)(const std::string& name);
-    extern std::vector<std::string> (*GetAllLonglink_ext)();
-    extern void (*MarkMainLonglink_ext)(const std::string& name);
-    
-    extern bool (*LongLinkIsConnected_ext)(const std::string& name);
-    extern void (*MakesureLonglinkConnected_ext)(const std::string& name);
+	extern void(*CreateLonglink_ext)(const LonglinkConfig& _config);
+	extern void(*DestroyLonglink_ext)(const std::string& name);
+	extern std::vector<std::string>(*GetAllLonglink_ext)();
+
+	extern bool(*LongLinkIsConnected_ext)(const std::string& name);
+	extern void(*MarkMainLonglink_ext)(const std::string& name);
+	extern void(*MakesureLonglinkConnected_ext)(const std::string& name);
 }}
 
 #endif /* MARS_STN_LOGIC_H_ */

--- a/samples/Windows/Business/ChatCGITask.cpp
+++ b/samples/Windows/Business/ChatCGITask.cpp
@@ -23,7 +23,7 @@
 #include "mars/stn/stn_logic.h"
 using namespace std;
 
-bool ChatCGITask::Req2Buf(uint32_t _taskid, void* const _user_context, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select)
+bool ChatCGITask::Req2Buf(uint32_t _taskid, void* const _user_context, const std::string& _user_id, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select, const std::string& _host)
 {
 	string data;
 	com::tencent::mars::sample::chat::proto::SendMessageRequest request;
@@ -37,7 +37,8 @@ bool ChatCGITask::Req2Buf(uint32_t _taskid, void* const _user_context, AutoBuffe
 	_outbuffer.Write(data.c_str(), data.size());
 	return true;
 }
-int ChatCGITask::Buf2Resp(uint32_t _taskid, void* const _user_context, const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select)
+
+int ChatCGITask::Buf2Resp(uint32_t _taskid, void* const _user_context, const std::string& _user_id, const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select)
 {
 	com::tencent::mars::sample::chat::proto::SendMessageResponse response;
 	response.ParseFromArray(_inbuffer.Ptr(), _inbuffer.Length());

--- a/samples/Windows/Business/ChatCGITask.h
+++ b/samples/Windows/Business/ChatCGITask.h
@@ -25,8 +25,8 @@
 class ChatCGITask : public CGITask 
 {
 public:
-	virtual bool Req2Buf(uint32_t _taskid, void* const _user_context, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select);
-	virtual int Buf2Resp(uint32_t _taskid, void* const _user_context, const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select);
+	virtual bool Req2Buf(uint32_t _taskid, void* const _user_context, const std::string& _user_id, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select, const std::string& _host);
+	virtual int Buf2Resp(uint32_t _taskid, void* const _user_context, const std::string& _user_id, const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select);
 
 	std::string user_;
 	std::string to_;

--- a/samples/Windows/Business/GetConvListCGITask.cpp
+++ b/samples/Windows/Business/GetConvListCGITask.cpp
@@ -22,7 +22,7 @@
 #include "mars/stn/stn_logic.h"
 using namespace std;
 
-bool GetConvListCGITask::Req2Buf(uint32_t _taskid, void* const _user_context, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select)
+bool GetConvListCGITask::Req2Buf(uint32_t _taskid, void* const _user_context, const std::string& _user_id, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select, const std::string& _host)
 {
 	string data;
 	com::tencent::mars::sample::proto::ConversationListRequest request;
@@ -33,7 +33,8 @@ bool GetConvListCGITask::Req2Buf(uint32_t _taskid, void* const _user_context, Au
 	_outbuffer.Write(data.c_str(), data.size());
 	return true;
 }
-int GetConvListCGITask::Buf2Resp(uint32_t _taskid, void* const _user_context, const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select)
+
+int GetConvListCGITask::Buf2Resp(uint32_t _taskid, void* const _user_context, const std::string& _user_id, const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select)
 {
 	com::tencent::mars::sample::proto::ConversationListResponse response;
 	response.ParseFromArray(_inbuffer.Ptr(), _inbuffer.Length());

--- a/samples/Windows/Business/GetConvListCGITask.h
+++ b/samples/Windows/Business/GetConvListCGITask.h
@@ -39,8 +39,8 @@ public:
 class GetConvListCGITask : public CGITask
 {
 public:
-	virtual bool Req2Buf(uint32_t _taskid, void* const _user_context, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select);
-	virtual int Buf2Resp(uint32_t _taskid, void* const _user_context, const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select);
+	virtual bool Req2Buf(uint32_t _taskid, void* const _user_context, const std::string& _user_id, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select, const std::string& _host);
+	virtual int Buf2Resp(uint32_t _taskid, void* const _user_context, const std::string& _user_id, const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select);
 
 	std::string access_token_;
 	boost::weak_ptr<GetConvListCGICallback> callback_;

--- a/samples/Windows/Business/HelloCGITask.cpp
+++ b/samples/Windows/Business/HelloCGITask.cpp
@@ -22,7 +22,7 @@
 #include "mars/stn/stn_logic.h"
 using namespace std;
 
-bool HelloCGITask::Req2Buf(uint32_t _taskid, void* const _user_context, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select)
+bool HelloCGITask::Req2Buf(uint32_t _taskid, void* const _user_context, const std::string& _user_id, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select, const std::string& _host)
 {
 	string data;
 	com::tencent::mars::sample::proto::HelloRequest request;
@@ -33,7 +33,8 @@ bool HelloCGITask::Req2Buf(uint32_t _taskid, void* const _user_context, AutoBuff
 	_outbuffer.Write(data.c_str(), data.size());
 	return true;
 }
-int HelloCGITask::Buf2Resp(uint32_t _taskid, void* const _user_context, const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select)
+
+int HelloCGITask::Buf2Resp(uint32_t _taskid, void* const _user_context, const std::string& _user_id, const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select)
 {
 	com::tencent::mars::sample::proto::HelloResponse response;
 	response.ParseFromArray(_inbuffer.Ptr(), _inbuffer.Length());

--- a/samples/Windows/Business/HelloCGITask.h
+++ b/samples/Windows/Business/HelloCGITask.h
@@ -30,11 +30,12 @@ class HelloCGICallback
 public:
 	virtual void OnResponse(HelloCGITask* task, const com::tencent::mars::sample::proto::HelloResponse& response) = 0;
 };
+
 class HelloCGITask : public CGITask 
 {
 public:
-	virtual bool Req2Buf(uint32_t _taskid, void* const _user_context, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select);
-	virtual int Buf2Resp(uint32_t _taskid, void* const _user_context, const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select);
+	virtual bool Req2Buf(uint32_t _taskid, void* const _user_context, const std::string& _user_id, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select, const std::string& _host);
+	virtual int Buf2Resp(uint32_t _taskid, void* const _user_context, const std::string& _user_id, const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select);
 
 	std::string user_;
 	std::string text_;

--- a/samples/Windows/Business/MarsWrapper.h
+++ b/samples/Windows/Business/MarsWrapper.h
@@ -35,19 +35,21 @@ class ChatMsgObserver
 public:
 	virtual void OnRecvChatMsg(const ChatMsg& msg) = 0;
 };
+
 class MarsWrapper : public PushObserver
 {
 public:
 	static MarsWrapper& Instance();
 
 
-	virtual void OnPush(uint64_t _channel_id, uint32_t _cmdid, uint32_t _taskid, const AutoBuffer& _body, const AutoBuffer& _extend);
+	virtual void OnPush(const std::string& _channel_id, uint32_t _cmdid, uint32_t _taskid, const AutoBuffer& _body, const AutoBuffer& _extend);
 
 	void setChatMsgObserver(ChatMsgObserver* _observer);
 	void sendChatMsg(const ChatMsg& _chat_msg);
 	void start();
 	void pingServer(const std::string& _name, const std::string& _text, boost::weak_ptr<HelloCGICallback> _callback);
 	void getConversationList(boost::weak_ptr<GetConvListCGICallback> _callback);
+
 protected:
 	MarsWrapper();
 	ChatMsgObserver* chat_msg_observer_;

--- a/samples/Windows/ChatDlg.cpp
+++ b/samples/Windows/ChatDlg.cpp
@@ -10,10 +10,12 @@ CChatDlg::CChatDlg()
 {
 	::LoadLibrary(CRichEditCtrl::GetLibraryName());
 }
+
 CChatDlg::~CChatDlg()
 {
 	MarsWrapper::Instance().setChatMsgObserver(NULL);
 }
+
 BOOL CChatDlg::PreTranslateMessage(MSG* pMsg)
 {
 	return CWindow::IsDialogMessage(pMsg);
@@ -24,6 +26,7 @@ BOOL CChatDlg::OnIdle()
 	UIUpdateChildWindows();
 	return FALSE;
 }
+
 LRESULT CChatDlg::OnInitDialog(UINT /*uMsg*/, WPARAM /*wParam*/, LPARAM /*lParam*/, BOOL& /*bHandled*/)
 {
 	m_edit = GetDlgItem(IDC_EDITMSG);
@@ -53,7 +56,6 @@ LRESULT CChatDlg::OnInitDialog(UINT /*uMsg*/, WPARAM /*wParam*/, LPARAM /*lParam
 
 	return true;
 }
-
 
 LRESULT CChatDlg::OnBnClickedBtnsendmsg(WORD /*wNotifyCode*/, WORD /*wID*/, HWND /*hWndCtl*/, BOOL& /*bHandled*/)
 {
@@ -88,6 +90,7 @@ LRESULT CChatDlg::OnBnClickedBtnsendmsg(WORD /*wNotifyCode*/, WORD /*wID*/, HWND
 
 	return 0;
 }
+
 void CChatDlg::OnRecvChatMsg(const ChatMsg& msg)
 {
 	m_editMsgFlow.SetSelNone();
@@ -104,7 +107,6 @@ void CChatDlg::OnRecvChatMsg(const ChatMsg& msg)
 
 	m_editMsgFlow.PostMessage(WM_VSCROLL, SB_BOTTOM);
 }
-
 
 void CChatDlg::SetChatInfo(const std::string& name, const std::string& topic)
 {

--- a/samples/Windows/PublicComponentV2/longlink_packer.cc
+++ b/samples/Windows/PublicComponentV2/longlink_packer.cc
@@ -1,5 +1,5 @@
 // Tencent is pleased to support the open source community by making Mars available.
-// Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+// Copyright (C) 2016 THL A29 Limited, a Tencent company. All rights reserved.
 
 // Licensed under the MIT License (the "License"); you may not use this file except in 
 // compliance with the License. You may obtain a copy of the License at
@@ -10,18 +10,19 @@
 // either express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 
+
 /*
-*  longlink_packer.cc
-*
-*  Created on: 2017-7-7
-*      Author: chenzihao
-*/
+ * longlink_packer.cc
+ *
+ *  Created on: 2012-7-18
+ *      Author: yerungui, caoshaokun
+ */
 
 #include "longlink_packer.h"
 
-#ifndef _WIN32
+#ifndef WIN32
 #include <arpa/inet.h>
-#endif
+#endif // !WIN32
 
 #ifdef __APPLE__
 #include "mars/xlog/xlogger.h"
@@ -45,6 +46,9 @@ struct __STNetMsgXpHeader {
 
 namespace mars {
 namespace stn {
+    
+LongLinkEncoder gDefaultLongLinkEncoder;
+    
 longlink_tracker* (*longlink_tracker::Create)()
 = []() {
     return new longlink_tracker;
@@ -83,85 +87,74 @@ static int __unpack_test(const void* _packed, size_t _packed_len, uint32_t& _cmd
     return LONGLINK_UNPACK_OK;
 }
 
-void (*longlink_pack)(uint32_t _cmdid, uint32_t _seq, const AutoBuffer& _body, const AutoBuffer& _extension, AutoBuffer& _packed, longlink_tracker* _tracker)
-= [](uint32_t _cmdid, uint32_t _seq, const AutoBuffer& _body, const AutoBuffer& _extension, AutoBuffer& _packed, longlink_tracker* _tracker) {
-    __STNetMsgXpHeader st = {0};
-    st.head_length = htonl(sizeof(__STNetMsgXpHeader));
-    st.client_version = htonl(sg_client_version);
-    st.cmdid = htonl(_cmdid);
-    st.seq = htonl(_seq);
-    st.body_length = htonl(_body.Length());
-
-    _packed.AllocWrite(sizeof(__STNetMsgXpHeader) + _body.Length());
-    _packed.Write(&st, sizeof(st));
-    
-    if (NULL != _body.Ptr()) _packed.Write(_body.Ptr(), _body.Length());
-    
-    _packed.Seek(0, AutoBuffer::ESeekStart);
-};
-
-
-int (*longlink_unpack)(const AutoBuffer& _packed, uint32_t& _cmdid, uint32_t& _seq, size_t& _package_len, AutoBuffer& _body, AutoBuffer& _extension, longlink_tracker* _tracker)
-= [](const AutoBuffer& _packed, uint32_t& _cmdid, uint32_t& _seq, size_t& _package_len, AutoBuffer& _body, AutoBuffer& _extension, longlink_tracker* _tracker) {
-   size_t body_len = 0;
-   int ret = __unpack_test(_packed.Ptr(), _packed.Length(), _cmdid,  _seq, _package_len, body_len);
-    
-    if (LONGLINK_UNPACK_OK != ret) return ret;
-    
-    _body.Write(AutoBuffer::ESeekCur, _packed.Ptr(_package_len-body_len), body_len);
-    
-    return ret;
-};
-
-
 #define NOOP_CMDID 6
 #define SIGNALKEEP_CMDID 243
 #define PUSH_DATA_TASKID 0
-
-uint32_t (*longlink_noop_cmdid)()
-= []() -> uint32_t {
-    return NOOP_CMDID;
-};
-
-bool  (*longlink_noop_isresp)(uint32_t _taskid, uint32_t _cmdid, uint32_t _recv_seq, const AutoBuffer& _body, const AutoBuffer& _extend)
-= [](uint32_t _taskid, uint32_t _cmdid, uint32_t _recv_seq, const AutoBuffer& _body, const AutoBuffer& _extend) {
-    return Task::kNoopTaskID == _taskid && NOOP_CMDID == _cmdid;
-};
-
-uint32_t (*signal_keep_cmdid)()
-= []() -> uint32_t {
-    return SIGNALKEEP_CMDID;
-};
-
-void (*longlink_noop_req_body)(AutoBuffer& _body, AutoBuffer& _extend)
-= [](AutoBuffer& _body, AutoBuffer& _extend) {
     
-};
-    
-void (*longlink_noop_resp_body)(const AutoBuffer& _body, const AutoBuffer& _extend)
-= [](const AutoBuffer& _body, const AutoBuffer& _extend) {
-    
-};
-
-uint32_t (*longlink_noop_interval)()
-= []() -> uint32_t {
-	return 0;
-};
-
-bool (*longlink_complexconnect_need_verify)()
-= []() {
-    return false;
-};
-
-bool (*longlink_ispush)(uint32_t _cmdid, uint32_t _taskid, const AutoBuffer& _body, const AutoBuffer& _extend)
-= [](uint32_t _cmdid, uint32_t _taskid, const AutoBuffer& _body, const AutoBuffer& _extend) {
-    return PUSH_DATA_TASKID == _taskid;
-};
-    
-bool (*longlink_identify_isresp)(uint32_t _sent_seq, uint32_t _cmdid, uint32_t _recv_seq, const AutoBuffer& _body, const AutoBuffer& _extend)
-= [](uint32_t _sent_seq, uint32_t _cmdid, uint32_t _recv_seq, const AutoBuffer& _body, const AutoBuffer& _extend) {
-    return _sent_seq == _recv_seq && 0 != _sent_seq;
-};
+    LongLinkEncoder::LongLinkEncoder() {
+        longlink_pack = [](uint32_t _cmdid, uint32_t _seq, const AutoBuffer& _body, const AutoBuffer& _extension, AutoBuffer& _packed, longlink_tracker* _tracker) {
+            __STNetMsgXpHeader st = {0};
+            st.head_length = htonl(sizeof(__STNetMsgXpHeader));
+            st.client_version = htonl(sg_client_version);
+            st.cmdid = htonl(_cmdid);
+            st.seq = htonl(_seq);
+            st.body_length = htonl(_body.Length());
+            
+            _packed.AllocWrite(sizeof(__STNetMsgXpHeader) + _body.Length());
+            _packed.Write(&st, sizeof(st));
+            
+            if (NULL != _body.Ptr()) _packed.Write(_body.Ptr(), _body.Length());
+            
+            _packed.Seek(0, AutoBuffer::ESeekStart);
+        };
+        
+        longlink_unpack = [](const AutoBuffer& _packed, uint32_t& _cmdid, uint32_t& _seq, size_t& _package_len, AutoBuffer& _body, AutoBuffer& _extension, longlink_tracker* _tracker) {
+            size_t body_len = 0;
+            int ret = __unpack_test(_packed.Ptr(), _packed.Length(), _cmdid,  _seq, _package_len, body_len);
+            
+            if (LONGLINK_UNPACK_OK != ret) return ret;
+            
+            _body.Write(AutoBuffer::ESeekCur, _packed.Ptr(_package_len-body_len), body_len);
+            
+            return ret;
+        };
+        
+        longlink_noop_cmdid = []() -> uint32_t {
+            return NOOP_CMDID;
+        };
+        
+        longlink_noop_isresp = [](uint32_t _taskid, uint32_t _cmdid, uint32_t _recv_seq, const AutoBuffer& _body, const AutoBuffer& _extend) {
+            return Task::kNoopTaskID == _taskid && NOOP_CMDID == _cmdid;
+        };
+        
+        signal_keep_cmdid = []() -> uint32_t {
+            return SIGNALKEEP_CMDID;
+        };
+        
+        longlink_noop_req_body = [](AutoBuffer& _body, AutoBuffer& _extend) {
+            
+        };
+        
+        longlink_noop_resp_body = [](const AutoBuffer& _body, const AutoBuffer& _extend) {
+            
+        };
+        
+        longlink_noop_interval = []() -> uint32_t {
+            return 0;
+        };
+        
+        longlink_complexconnect_need_verify = []() {
+            return false;
+        };
+        
+        longlink_ispush = [](uint32_t _cmdid, uint32_t _taskid, const AutoBuffer& _body, const AutoBuffer& _extend) {
+            return PUSH_DATA_TASKID == _taskid;
+        };
+        
+        longlink_identify_isresp = [](uint32_t _sent_seq, uint32_t _cmdid, uint32_t _recv_seq, const AutoBuffer& _body, const AutoBuffer& _extend) {
+            return _sent_seq == _recv_seq && 0 != _sent_seq;
+        };
+    }
 
 }
 }

--- a/samples/Windows/PublicComponentV2/longlink_packer.h
+++ b/samples/Windows/PublicComponentV2/longlink_packer.h
@@ -1,5 +1,5 @@
 // Tencent is pleased to support the open source community by making Mars available.
-// Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+// Copyright (C) 2016 THL A29 Limited, a Tencent company. All rights reserved.
 
 // Licensed under the MIT License (the "License"); you may not use this file except in 
 // compliance with the License. You may obtain a copy of the License at
@@ -10,18 +10,20 @@
 // either express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 
+
 /*
-*  longlink_packer.h
-*
-*  Created on: 2017-7-7
-*      Author: chenzihao
-*/
+ * longlink_packer.h
+ *
+ *  Created on: 2012-7-18
+ *      Author: yerungui
+ */
 
 #ifndef STN_SRC_LONGLINK_PACKER_H_
 #define STN_SRC_LONGLINK_PACKER_H_
 
 #include <stdlib.h>
 #include <stdint.h>
+#include <functional>
 
 #define LONGLINK_UNPACK_CONTINUE (-2)
 #define LONGLINK_UNPACK_FALSE (-1)
@@ -47,6 +49,48 @@ public:
 public:
     virtual ~longlink_tracker(){};
 };
+
+class LongLinkEncoder {
+ public:
+    LongLinkEncoder();
+
+    /**
+     * package the request data
+     * _cmdid: business identifier
+     * _seq: task id
+     * _raw: business send buffer
+     * _packed: business send buffer + request header
+     */
+    std::function<void (uint32_t _cmdid, uint32_t _seq, const AutoBuffer& _body, const AutoBuffer& _extension, AutoBuffer& _packed, longlink_tracker* _tracker)> longlink_pack;
+
+    /**
+     * unpackage the response data
+     * _packed: data received from server
+     * _cmdid: business identifier
+     * _seq: task id
+     * _package_len:
+     * _body: business receive buffer
+     * return: 0 if unpackage succ
+     */
+    std::function<int (const AutoBuffer& _packed, uint32_t& _cmdid, uint32_t& _seq, size_t& _package_len, AutoBuffer& _body, AutoBuffer& _extension, longlink_tracker* _tracker)> longlink_unpack;
+
+    //heartbeat signal to keep longlink network alive
+    std::function<uint32_t ()> longlink_noop_cmdid;
+    std::function<bool (uint32_t _taskid, uint32_t _cmdid, uint32_t _recv_seq, const AutoBuffer& _body, const AutoBuffer& _extend)> longlink_noop_isresp;
+    std::function<uint32_t ()> signal_keep_cmdid;
+    std::function<void (AutoBuffer& _body, AutoBuffer& _extend)> longlink_noop_req_body;
+    std::function<void (const AutoBuffer& _body, const AutoBuffer& _extend)> longlink_noop_resp_body;
+    std::function<uint32_t ()> longlink_noop_interval;
+    std::function<bool ()> longlink_complexconnect_need_verify;
+
+    /**
+     * return: whether the received data is pushing from server or not
+     */
+    std::function<bool (uint32_t _cmdid, uint32_t _taskid, const AutoBuffer& _body, const AutoBuffer& _extend)> longlink_ispush;
+    std::function<bool (uint32_t _sent_seq, uint32_t _cmdid, uint32_t _recv_seq, const AutoBuffer& _body, const AutoBuffer& _extend)> longlink_identify_isresp;
+};
+
+extern LongLinkEncoder gDefaultLongLinkEncoder;
 
 /**
  * package the request data

--- a/samples/Windows/PublicComponentV2/shortlink_packer.cc
+++ b/samples/Windows/PublicComponentV2/shortlink_packer.cc
@@ -1,5 +1,5 @@
 // Tencent is pleased to support the open source community by making Mars available.
-// Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+// Copyright (C) 2016 THL A29 Limited, a Tencent company. All rights reserved.
 
 // Licensed under the MIT License (the "License"); you may not use this file except in 
 // compliance with the License. You may obtain a copy of the License at
@@ -11,11 +11,11 @@
 // limitations under the License.
 
 /*
-*  shortlink_packer.cc
-*
-*  Created on: 2017-7-7
-*      Author: chenzihao
-*/
+ * shortlink_packer.cc
+ *
+ *  Created on: 2016-03-15
+ *      Author: yanguoyue
+ */
 
 #include "shortlink_packer.h"
 #include "mars/comm/http.h"

--- a/samples/Windows/PublicComponentV2/shortlink_packer.h
+++ b/samples/Windows/PublicComponentV2/shortlink_packer.h
@@ -1,5 +1,5 @@
 // Tencent is pleased to support the open source community by making Mars available.
-// Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+// Copyright (C) 2016 THL A29 Limited, a Tencent company. All rights reserved.
 
 // Licensed under the MIT License (the "License"); you may not use this file except in 
 // compliance with the License. You may obtain a copy of the License at
@@ -11,11 +11,11 @@
 // limitations under the License.
 
 /*
-*  shortlink_packer.h
-*
-*  Created on: 2017-7-7
-*      Author: chenzihao
-*/
+ * shortlink_packer.h
+ *
+ *  Created on: 2016-03-15
+ *      Author: yanguoyue
+ */
 
 #ifndef SRC_SHORTLINK_PACKER_H_
 #define SRC_SHORTLINK_PACKER_H_
@@ -35,7 +35,7 @@ public:
     virtual ~shortlink_tracker(){};
 };
     
-extern void (*shortlink_pack)(const std::string& _url, const std::map<std::string, std::string>& _headers, const AutoBuffer& _body, const AutoBuffer& _extension, AutoBuffer& _out_buff, shortlink_tracker* _tracker);
+    extern void (*shortlink_pack)(const std::string& _url, const std::map<std::string, std::string>& _headers, const AutoBuffer& _body, const AutoBuffer& _extension, AutoBuffer& _out_buff, shortlink_tracker* _tracker);
 
 }}
 

--- a/samples/Windows/PublicComponentV2/stn_callback.cpp
+++ b/samples/Windows/PublicComponentV2/stn_callback.cpp
@@ -53,27 +53,27 @@ void StnCallBack::TrafficData(ssize_t _send, ssize_t _recv) {
         
 std::vector<std::string> StnCallBack::OnNewDns(const std::string& _host) {
     std::vector<std::string> vector;
-    vector.push_back("118.89.24.72");
+    vector.push_back("118.89.24.72"); // modify to yours
     return vector;
 }
 
-void StnCallBack::OnPush(uint64_t _channel_id, uint32_t _cmdid, uint32_t _taskid, const AutoBuffer& _body, const AutoBuffer& _extend) {
-    NetworkService::Instance().OnPush(_channel_id, _cmdid, _taskid, _body, _extend);
-    
+void StnCallBack::OnPush(const std::string& _channel_id, uint32_t _cmdid, uint32_t _taskid, const AutoBuffer& _body, const AutoBuffer& _extend) {
+   
+	NetworkService::Instance().OnPush(_channel_id, _cmdid, _taskid, _body, _extend);
 }
 
-bool StnCallBack::Req2Buf(uint32_t _taskid, void* const _user_context, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select, const std::string& _host) {
+bool StnCallBack::Req2Buf(uint32_t _taskid, void* const _user_context, const std::string& _user_id, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select, const std::string& _host) {
 	
-	return NetworkService::Instance().Req2Buf(_taskid, _user_context, _outbuffer, _extend, _error_code, _channel_select);
+	return NetworkService::Instance().Req2Buf(_taskid, _user_context, _user_id, _outbuffer, _extend, _error_code, _channel_select, _host);
 }
 
-int StnCallBack::Buf2Resp(uint32_t _taskid, void* const _user_context, const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select) {
+int StnCallBack::Buf2Resp(uint32_t _taskid, void* const _user_context, const std::string& _user_id, const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select) {
     
-	return NetworkService::Instance().Buf2Resp(_taskid, _user_context, _inbuffer, _extend, _error_code, _channel_select);
+	return NetworkService::Instance().Buf2Resp(_taskid, _user_context, _user_id, _inbuffer, _extend, _error_code, _channel_select);
 }
 
-int StnCallBack::OnTaskEnd(uint32_t _taskid, void* const _user_context, int _error_type, int _error_code) {
-	NetworkService::Instance().OnTaskEnd(_taskid, _user_context, _error_type, _error_code);
+int StnCallBack::OnTaskEnd(uint32_t _taskid, void* const _user_context, const std::string& _user_id, int _error_type, int _error_code) {
+	NetworkService::Instance().OnTaskEnd(_taskid, _user_context, _user_id, _error_type, _error_code);
 	return 0;
 }
 
@@ -99,17 +99,17 @@ void StnCallBack::ReportConnectStatus(int _status, int longlink_status) {
 // synccheck：长链成功后由网络组件触发
 // 需要组件组包，发送一个req过去，网络成功会有resp，但没有taskend，处理事务时要注意网络时序
 // 不需组件组包，使用长链做一个sync，不用重试
-int  StnCallBack::GetLonglinkIdentifyCheckBuffer(AutoBuffer& _identify_buffer, AutoBuffer& _buffer_hash, int32_t& _cmdid) {
+int  StnCallBack::GetLonglinkIdentifyCheckBuffer(const std::string& _channel_id, AutoBuffer& _identify_buffer, AutoBuffer& _buffer_hash, int32_t& _cmdid) {
     
 	_cmdid = 2;
     return IdentifyMode::kCheckNever;
 }
 
-bool StnCallBack::OnLonglinkIdentifyResponse(const AutoBuffer& _response_buffer, const AutoBuffer& _identify_buffer_hash) {
+bool StnCallBack::OnLonglinkIdentifyResponse(const std::string& _channel_id, const AutoBuffer& _response_buffer, const AutoBuffer& _identify_buffer_hash) {
     
     return false;
 }
-//
+
 void StnCallBack::RequestSync() {
 
 }

--- a/samples/Windows/PublicComponentV2/stn_callback.h
+++ b/samples/Windows/PublicComponentV2/stn_callback.h
@@ -47,21 +47,21 @@ public:
     //底层询问上层该host对应的ip列表
     virtual std::vector<std::string> OnNewDns(const std::string& _host);
     //网络层收到push消息回调
-    virtual void OnPush(uint64_t _channel_id, uint32_t _cmdid, uint32_t _taskid, const AutoBuffer& _body, const AutoBuffer& _extend);
+    virtual void OnPush(const std::string& _channel_id, uint32_t _cmdid, uint32_t _taskid, const AutoBuffer& _body, const AutoBuffer& _extend);
     //底层获取task要发送的数据
-    virtual bool Req2Buf(uint32_t _taskid, void* const _user_context, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select, const std::string& _host);
+    virtual bool Req2Buf(uint32_t _taskid, void* const _user_context, const std::string& _user_id, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select, const std::string& _host);
     //底层回包返回给上层解析
-    virtual int Buf2Resp(uint32_t _taskid, void* const _user_context, const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select);
+    virtual int Buf2Resp(uint32_t _taskid, void* const _user_context, const std::string& _user_id, const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select);
     //任务执行结束
-    virtual int  OnTaskEnd(uint32_t _taskid, void* const _user_context, int _error_type, int _error_code);
+    virtual int OnTaskEnd(uint32_t _taskid, void* const _user_context, const std::string& _user_id, int _error_type, int _error_code);
 
     //上报网络连接状态
     virtual void ReportConnectStatus(int _status, int longlink_status);
     //长连信令校验 ECHECK_NOW, ECHECK_NEVER = 1, ECHECK_NEXT = 2
-    virtual int  GetLonglinkIdentifyCheckBuffer(AutoBuffer& _identify_buffer, AutoBuffer& _buffer_hash, int32_t& _cmdid);
+    virtual int GetLonglinkIdentifyCheckBuffer(const std::string& _channel_id, AutoBuffer& _identify_buffer, AutoBuffer& _buffer_hash, int32_t& _cmdid);
     //长连信令校验回包
-    virtual bool OnLonglinkIdentifyResponse(const AutoBuffer& _response_buffer, const AutoBuffer& _identify_buffer_hash);
-    //
+    virtual bool OnLonglinkIdentifyResponse(const std::string& _channel_id, const AutoBuffer& _response_buffer, const AutoBuffer& _identify_buffer_hash);
+
     virtual void RequestSync();
 
 

--- a/samples/Windows/PublicComponentV2/stnproto_logic.h
+++ b/samples/Windows/PublicComponentV2/stnproto_logic.h
@@ -1,5 +1,5 @@
 // Tencent is pleased to support the open source community by making Mars available.
-// Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+// Copyright (C) 2016 THL A29 Limited, a Tencent company. All rights reserved.
 
 // Licensed under the MIT License (the "License"); you may not use this file except in 
 // compliance with the License. You may obtain a copy of the License at
@@ -11,11 +11,11 @@
 // limitations under the License.
 
 /*
-*  stnproto_logic.h
-*
-*  Created on: 2017-7-7
-*      Author: chenzihao
-*/
+ * stnproto_logic.h
+ *
+ *  Created on: 2016-03-15
+ *      Author: caoshaokun
+ */
 
 #include <stdint.h>
 

--- a/samples/Windows/Wrapper/CGITask.h
+++ b/samples/Windows/Wrapper/CGITask.h
@@ -30,12 +30,13 @@ enum ChannelType
 	ChannelType_LongConn = 2,
 	ChannelType_All = 3
 } ;
+
 class CGITask
 {
 public:
 	virtual ~CGITask() {};
-	virtual bool Req2Buf(uint32_t _taskid, void* const _user_context, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select) = 0;
-	virtual int Buf2Resp(uint32_t _taskid, void* const _user_context, const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select) = 0;
+	virtual bool Req2Buf(uint32_t _taskid, void* const _user_context, const std::string& _user_id, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select, const std::string& _host) = 0;
+	virtual int Buf2Resp(uint32_t _taskid, void* const _user_context, const std::string& _user_id, const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select) = 0;
 
 
 	uint32_t taskid_;

--- a/samples/Windows/Wrapper/NetworkObserver.h
+++ b/samples/Windows/Wrapper/NetworkObserver.h
@@ -28,7 +28,7 @@
 class PushObserver
 {
 public:
-	virtual void OnPush(uint64_t _channel_id, uint32_t _cmdid, uint32_t _taskid, const AutoBuffer& _body, const AutoBuffer& _extend) = 0;
+	virtual void OnPush(const std::string& _channel_id, uint32_t _cmdid, uint32_t _taskid, const AutoBuffer& _body, const AutoBuffer& _extend) = 0;
 
 };
 

--- a/samples/Windows/Wrapper/NetworkService.cpp
+++ b/samples/Windows/Wrapper/NetworkService.cpp
@@ -26,6 +26,9 @@
 #include "PublicComponentV2/stn_callback.h"
 #include "PublicComponentV2/app_callback.h"
 
+#include "mars/comm/xlogger/xloggerbase.h"
+#include "mars/log/appender.h"
+
 #include "proto/generate/main.pb.h"
 #include <windows.h>
 using namespace std;
@@ -38,34 +41,68 @@ NetworkService& NetworkService::Instance()
 
 NetworkService::NetworkService()
 {
+	__Openlog();
 	__Init();
 }
+
 NetworkService::~NetworkService()
 {
+	__Cleanup();
+	__Closelog();
 }
 
 void NetworkService::setClientVersion(uint32_t _client_version)
 {
 	mars::stn::SetClientVersion(_client_version);
 }
+
 void NetworkService::setShortLinkDebugIP(const std::string& _ip, unsigned short _port)
 {
 	mars::stn::SetShortlinkSvrAddr(_port, _ip);
 }
+
 void NetworkService::setShortLinkPort(unsigned short _port)
 {
 	mars::stn::SetShortlinkSvrAddr(_port, "");
 }
+
 void NetworkService::setLongLinkAddress(const std::string& _ip, unsigned short _port, const std::string& _debug_ip)
 {
 	vector<uint16_t> ports;
 	ports.push_back(_port);
 	mars::stn::SetLonglinkSvrAddr(_ip, ports, _debug_ip);
 }
+
 void NetworkService::start()
 {
 	mars::baseevent::OnForeground(true);
 	mars::stn::MakesureLonglinkConnected();
+}
+
+void NetworkService::__Openlog()
+{
+#if _DEBUG
+	xlogger_SetLevel(kLevelDebug);
+	appender_set_console_log(true);
+	extern std::function<void(char* _log)> g_console_log_fun;
+	g_console_log_fun = [](char* _log) {
+		::OutputDebugStringA(_log);
+	};
+#else
+	xlogger_SetLevel(kLevelInfo);
+	appender_set_console_log(false);
+#endif
+
+	XLogConfig config;
+	config.logdir_ = "Log"; //use your log path
+	config.nameprefix_ = "Sample";
+	config.pub_key_ = ""; //use you pubkey for log encrypt
+	appender_open(config);
+}
+
+void NetworkService::__Closelog()
+{
+	appender_close();
 }
 
 void NetworkService::__Init()
@@ -73,6 +110,11 @@ void NetworkService::__Init()
 	mars::stn::SetCallback(mars::stn::StnCallBack::Instance());
 	mars::app::SetCallback(mars::app::AppCallBack::Instance());
 	mars::baseevent::OnCreate();
+}
+
+void NetworkService::__Cleanup()
+{
+	mars::baseevent::OnDestroy();
 }
 
 int NetworkService::startTask(CGITask* task)
@@ -88,21 +130,21 @@ int NetworkService::startTask(CGITask* task)
 	return ctask.taskid;
 }
 
-bool NetworkService::Req2Buf(uint32_t _taskid, void* const _user_context, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select)
+bool NetworkService::Req2Buf(uint32_t _taskid, void* const _user_context, const std::string& _user_id, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select, const std::string& _host)
 {
 	auto it = map_task_.find(_taskid);
 	if (it == map_task_.end())return false;
-	return it->second->Req2Buf(_taskid, _user_context, _outbuffer, _extend, _error_code, _channel_select);
+	return it->second->Req2Buf(_taskid, _user_context, _user_id, _outbuffer, _extend, _error_code, _channel_select, _host);
 }
 
-int NetworkService::Buf2Resp(uint32_t _taskid, void* const _user_context, const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select)
+int NetworkService::Buf2Resp(uint32_t _taskid, void* const _user_context, const std::string& _user_id, const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select)
 {
 	auto it = map_task_.find(_taskid);
 	if (it == map_task_.end())return mars::stn::kTaskFailHandleDefault;
-	return it->second->Buf2Resp(_taskid, _user_context, _inbuffer, _extend, _error_code, _channel_select);
+	return it->second->Buf2Resp(_taskid, _user_context, _user_id, _inbuffer, _extend, _error_code, _channel_select);
 }
 
-int NetworkService::OnTaskEnd(uint32_t _taskid, void* const _user_context, int _error_type, int _error_code)
+int NetworkService::OnTaskEnd(uint32_t _taskid, void* const _user_context, const std::string& _user_id, int _error_type, int _error_code)
 {
 	auto it = map_task_.find(_taskid);
 	if (it != map_task_.end())
@@ -113,7 +155,7 @@ int NetworkService::OnTaskEnd(uint32_t _taskid, void* const _user_context, int _
 	return 0;
 }
 
-void NetworkService::OnPush(uint64_t _channel_id, uint32_t _cmdid, uint32_t _taskid, const AutoBuffer& _body, const AutoBuffer& _extend)
+void NetworkService::OnPush(const std::string& _channel_id, uint32_t _cmdid, uint32_t _taskid, const AutoBuffer& _body, const AutoBuffer& _extend)
 {
 	auto it = map_push_observer_.find(_cmdid);
 	if (it != map_push_observer_.end() && it->second)

--- a/samples/Windows/Wrapper/NetworkService.cpp
+++ b/samples/Windows/Wrapper/NetworkService.cpp
@@ -96,7 +96,8 @@ void NetworkService::__Openlog()
 	XLogConfig config;
 	config.logdir_ = "Log"; //use your log path
 	config.nameprefix_ = "Sample";
-	config.pub_key_ = ""; //use you pubkey for log encrypt
+	config.pub_key_ = ""; //use your pubkey for log encrypt
+	config.cachedir_ = ""; //use your cache path
 	appender_open(config);
 }
 

--- a/samples/Windows/Wrapper/NetworkService.h
+++ b/samples/Windows/Wrapper/NetworkService.h
@@ -32,10 +32,11 @@ class NetworkService
 {
 public:
 	static NetworkService& Instance();
-	bool Req2Buf(uint32_t _taskid, void* const _user_context, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select);
-	int Buf2Resp(uint32_t _taskid, void* const _user_context, const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select);
-	int OnTaskEnd(uint32_t _taskid, void* const _user_context, int _error_type, int _error_code);
-	void OnPush(uint64_t _channel_id, uint32_t _cmdid, uint32_t _taskid, const AutoBuffer& _body, const AutoBuffer& _extend);
+
+	void OnPush(const std::string& _channel_id, uint32_t _cmdid, uint32_t _taskid, const AutoBuffer& _body, const AutoBuffer& _extend);
+	bool Req2Buf(uint32_t _taskid, void* const _user_context, const std::string& _user_id, AutoBuffer& _outbuffer, AutoBuffer& _extend, int& _error_code, const int _channel_select, const std::string& _host);
+	int Buf2Resp(uint32_t _taskid, void* const _user_context, const std::string& _user_id, const AutoBuffer& _inbuffer, const AutoBuffer& _extend, int& _error_code, const int _channel_select);
+	int OnTaskEnd(uint32_t _taskid, void* const _user_context, const std::string& _user_id, int _error_type, int _error_code);
 
 	void setClientVersion(uint32_t _client_version);
 	void setShortLinkDebugIP(const std::string& _ip, unsigned short _port);
@@ -50,7 +51,11 @@ protected:
 	NetworkService();
 	~NetworkService();
 
+	void __Openlog();
+	void __Closelog();
+
 	void __Init();
+	void __Cleanup();
 private:
 	std::map<uint32_t, CGITask*> map_task_;
 	std::map<uint32_t, PushObserver*> map_push_observer_;


### PR DESCRIPTION
修复vs2015编译错误，修改windows demo部分代码，修改部分README.md

建议:
1.直接将xlog所使用的zstd直接编译成mars/openssl/openssl_lib_windows/x86这样的依赖库放于文件夹中(mtd && mt)
以避免编译时出现
unresolved external symbol _ZSTD_createCCtx等error
需要将 lib 添加于 Additional Dependencies

2.注释掉有关WeakNetworkLogic的代码
原因:在我退出释放mars的时候，走到
bool LongLinkTaskManager::__SingleRespHandle(std::list<TaskProfile>::iterator _it, ErrCmdType _err_type, int _err_code, int _fail_handle, const ConnectProfile& _connect_profile) {
....
WeakNetworkLogic::Singleton::Instance()->OnTaskEvent(*_it); // 会出现卡死，看起来像没锁的原因，单步队列，能走到之后的atexit

3.longlink_task_manager.cc 中的 lock 问题
bool LongLinkTaskManager::AddLongLink(const LonglinkConfig& _config) {
    auto longlink = GetLongLink(_config.name); // lock
    ...
   ScopedLock lock(meta_mutex_); // lock
   ...
   longlink = GetLongLink(_config.name); // lock
以及
void LongLinkTaskManager::ReleaseLongLink(const std::string _name) {
  ScopedLock lock(meta_mutex_); // lock

4.longlink.cc 中的 内存增长 问题
由于
void LongLink::__RunReadWrite(SOCKET _sock, ErrCmdType& _errtype, int& _errcode, ConnectProfile& _profile) {
中使用了
std::vector<LongLinkNWriteData> nsent_datas;
..
nsent_datas.push_back(nwrite);
对发送的数据进行统计
设想如下场景，长连接处于稳定的情况下，但由于没有设置阈值等缘故，nsent_datas会一直push
导致内存的持续增长，只有在socket关闭或者其他情况走完__RunReadWrite才会对空间进行释放
从而导致在稳定的连接下，内存会不断的增长