### PR TITLE
fix Android build link errors of log module

### DIFF
--- a/mars/log/CMakeLists.txt
+++ b/mars/log/CMakeLists.txt
@@ -55,6 +55,10 @@ elseif(ANDROID)
     get_filename_component(EXPORT_EXP_FILE jni/export.exp ABSOLUTE)
     set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--version-script=${EXPORT_EXP_FILE}")
 
+    link_directories(../comm)
+    link_libraries(comm)
+    link_directories(../boost)
+    link_libraries(mars-boost)
 
 endif()
 


### PR DESCRIPTION
Fix the following build errors:

[100%] Linking CXX shared library libmarsstn.so
/Users/xykong/workspace/github/mars/mars/log/../boost/iostreams/device/mapped_file.hpp:295: error: undefined reference to 'mars_boost::iostreams::mapped_file_source::is_open() const'
/Users/xykong/workspace/github/mars/mars/log/../boost/iostreams/device/mapped_file.hpp:298: error: undefined reference to 'mars_boost::iostreams::mapped_file_source::operator!() const'
/Users/xykong/workspace/github/mars/mars/log/../boost/iostreams/device/mapped_file.hpp:299: error: undefined reference to 'mars_boost::iostreams::mapped_file_source::flags() const'
/Users/xykong/workspace/github/mars/mars/log/src/appender.cc:235: error: undefined reference to 'PtrBuffer::Ptr()'
/Users/xykong/workspace/github/mars/mars/log/../boost/iostreams/device/mapped_file.hpp:466: error: undefined reference to 'mars_boost::iostreams::mapped_file_source::data() const'
/Users/xykong/workspace/github/mars/mars/log/src/appender.cc:232: error: undefined reference to 'CloseMmapFile(mars_boost::iostreams::mapped_file&)'
/Users/xykong/workspace/github/mars/mars/log/../boost/iostreams/device/mapped_file.hpp:243: error: undefined reference to 'mars_boost::iostreams::mapped_file_source::mapped_file_source()'
/Users/xykong/workspace/github/mars/mars/log/src/appender.cc:275: error: undefined reference to 'OpenMmapFile(char const*, unsigned int, mars_boost::iostreams::mapped_file&)'
/Users/xykong/workspace/github/mars/mars/log/../boost/iostreams/device/mapped_file.hpp:299: error: undefined reference to 'mars_boost::iostreams::mapped_file_source::flags() const'
/Users/xykong/workspace/github/mars/mars/log/../boost/iostreams/device/mapped_file.hpp:299: error: undefined reference to 'mars_boost::iostreams::mapped_file_source::flags() const'
/Users/xykong/workspace/github/mars/mars/log/../boost/iostreams/device/mapped_file.hpp:466: error: undefined reference to 'mars_boost::iostreams::mapped_file_source::data() const'
/Users/xykong/workspace/github/mars/mars/log/../boost/iostreams/device/mapped_file.hpp:466: error: undefined reference to 'mars_boost::iostreams::mapped_file_source::data() const'
/Users/xykong/workspace/github/mars/mars/log/src/appender.cc:292: error: undefined reference to 'PtrBuffer::Ptr()'
/Users/xykong/workspace/github/mars/mars/log/../boost/iostreams/device/mapped_file.hpp:295: error: undefined reference to 'mars_boost::iostreams::mapped_file_source::is_open() const'
/Users/xykong/workspace/github/mars/mars/log/src/appender.cc:293: error: undefined reference to 'CloseMmapFile(mars_boost::iostreams::mapped_file&)'
/Users/xykong/workspace/github/mars/mars/log/src/appender.cc:158: error: undefined reference to 'PtrBuffer::PtrBuffer(void*, unsigned int, unsigned int)'
/Users/xykong/workspace/github/mars/mars/log/src/appender.cc:165: error: undefined reference to 'PtrBuffer::~PtrBuffer()'
/Users/xykong/workspace/github/mars/mars/log/src/appender.cc:866: error: undefined reference to 'PtrBuffer::PtrBuffer(void*, unsigned int, unsigned int)'
/Users/xykong/workspace/github/mars/mars/log/src/appender.cc:870: error: undefined reference to 'PtrBuffer::Ptr()'
/Users/xykong/workspace/github/mars/mars/log/src/appender.cc:870: error: undefined reference to 'PtrBuffer::Length() const'
/Users/xykong/workspace/github/mars/mars/log/src/appender.cc:873: error: undefined reference to 'PtrBuffer::~PtrBuffer()'
/Users/xykong/workspace/github/mars/mars/log/src/appender.cc:881: error: undefined reference to 'PtrBuffer::PtrBuffer(void*, unsigned int, unsigned int)'
/Users/xykong/workspace/github/mars/mars/log/src/appender.cc:884: error: undefined reference to 'PtrBuffer::Length() const'
/Users/xykong/workspace/github/mars/mars/log/src/appender.cc:885: error: undefined reference to 'PtrBuffer::Length() const'
/Users/xykong/workspace/github/mars/mars/log/src/appender.cc:886: error: undefined reference to 'PtrBuffer::Length(long, unsigned int)'
/Users/xykong/workspace/github/mars/mars/log/src/appender.cc:889: error: undefined reference to 'PtrBuffer::Ptr()'
/Users/xykong/workspace/github/mars/mars/log/src/appender.cc:889: error: undefined reference to 'PtrBuffer::Length() const'
/Users/xykong/workspace/github/mars/mars/log/src/appender.cc:894: error: undefined reference to 'PtrBuffer::~PtrBuffer()'
/Users/xykong/workspace/github/mars/mars/log/src/formater.cc:55: error: undefined reference to 'PtrBuffer::MaxLength() const'
/Users/xykong/workspace/github/mars/mars/log/src/formater.cc:73: error: undefined reference to 'ExtractFileName'
/Users/xykong/workspace/github/mars/mars/log/src/formater.cc:102: error: undefined reference to 'PtrBuffer::PosPtr()'
/Users/xykong/workspace/github/mars/mars/log/src/formater.cc:59: error: undefined reference to 'PtrBuffer::MaxLength() const'
/Users/xykong/workspace/github/mars/mars/log/src/formater.cc:60: error: undefined reference to 'PtrBuffer::PosPtr()'
/Users/xykong/workspace/github/mars/mars/log/src/formater.cc:61: error: undefined reference to 'PtrBuffer::Pos() const'
/Users/xykong/workspace/github/mars/mars/log/src/formater.cc:61: error: undefined reference to 'PtrBuffer::Length(long, unsigned int)'
/Users/xykong/workspace/github/mars/mars/log/../../mars/comm/ptrbuffer.h:45: error: undefined reference to 'PtrBuffer::Write(void const*, unsigned int)'
/Users/xykong/workspace/github/mars/mars/log/src/formater.cc:108: error: undefined reference to 'PtrBuffer::Pos() const'
/Users/xykong/workspace/github/mars/mars/log/src/formater.cc:108: error: undefined reference to 'PtrBuffer::Length(long, unsigned int)'
/Users/xykong/workspace/github/mars/mars/log/src/formater.cc:117: error: undefined reference to 'PtrBuffer::MaxLength() const'
/Users/xykong/workspace/github/mars/mars/log/src/formater.cc:117: error: undefined reference to 'PtrBuffer::MaxLength() const'
/Users/xykong/workspace/github/mars/mars/log/src/formater.cc:121: error: undefined reference to 'PtrBuffer::Write(void const*, unsigned int)'
/Users/xykong/workspace/github/mars/mars/log/src/formater.cc:128: error: undefined reference to 'PtrBuffer::PosPtr()'
/Users/xykong/workspace/github/mars/mars/log/src/formater.cc:128: error: undefined reference to 'PtrBuffer::Write(void const*, unsigned int)'
/Users/xykong/workspace/github/mars/mars/log/src/log_base_buffer.cc:184: error: undefined reference to 'PtrBuffer::PtrBuffer()'
/Users/xykong/workspace/github/mars/mars/log/src/log_base_buffer.cc:187: error: undefined reference to 'PtrBuffer::Attach(void*, unsigned int)'
/Users/xykong/workspace/github/mars/mars/log/src/log_base_buffer.cc:287: error: undefined reference to 'PtrBuffer::Length(long, unsigned int)'
/Users/xykong/workspace/github/mars/mars/log/src/log_base_buffer.cc:193: error: undefined reference to 'PtrBuffer::~PtrBuffer()'
/Users/xykong/workspace/github/mars/mars/log/src/log_base_buffer.cc:234: error: undefined reference to 'PtrBuffer::PosPtr()'
/Users/xykong/workspace/github/mars/mars/log/src/log_base_buffer.cc:240: error: undefined reference to 'PtrBuffer::Write(void const*, unsigned int)'
/Users/xykong/workspace/github/mars/mars/log/src/log_base_buffer.cc:250: error: undefined reference to 'PtrBuffer::Write(void const*, unsigned int, long)'
/Users/xykong/workspace/github/mars/mars/log/jni/ConsoleLog.cc:31: error: undefined reference to 'ExtractFileName'
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [libmarsstn.so] Error 1
make[1]: *** [CMakeFiles/marsstn.dir/all] Error 2
make: *** [all] Error 2
!!!!!!!!!!!!!!!!!!build fail!!!!!!!!!!!!!!!!!!!!