### PR TITLE
fix appender close notifyAll(true)

### DIFF
--- a/mars/log/src/appender.cc
+++ b/mars/log/src/appender.cc
@@ -220,7 +220,7 @@ void XloggerAppender::Close() {
 
     log_close_ = true;
 
-    cond_buffer_async_.notifyAll();
+    cond_buffer_async_.notifyAll(true);
 
     if (thread_async_.isruning())
         thread_async_.join();


### PR DESCRIPTION
notifyAll如果比AsyncLogThread里的wait先调用，就可能会导致主线程一直join