### PR TITLE
fix: WriteNoFormat add null check

### DIFF
--- a/mars/comm/xlogger/xlogger.h
+++ b/mars/comm/xlogger/xlogger.h
@@ -101,7 +101,9 @@ class XMessage {
 #endif
     XMessage&
     WriteNoFormat(const char* _log) {
-        m_message += _log;
+        if (_log) {
+            m_message += _log;
+        }
         return *this;
     }
 #ifdef __GNUC__
@@ -109,7 +111,9 @@ class XMessage {
 #endif
     XMessage&
     WriteNoFormat(const TypeSafeFormat&, const char* _log) {
-        m_message += _log;
+        if (_log) {
+            m_message += _log;
+        }
         return *this;
     }
 
@@ -197,7 +201,9 @@ class XLogger {
 #endif
     XLogger&
     WriteNoFormat(const char* _log) {
-        m_message += _log;
+        if (_log) {
+            m_message += _log;
+        }
         return *this;
     }
 #ifdef __GNUC__
@@ -205,7 +211,9 @@ class XLogger {
 #endif
     XLogger&
     WriteNoFormat(const TypeSafeFormat&, const char* _log) {
-        m_message += _log;
+        if (_log) {
+            m_message += _log;
+        }
         return *this;
     }
 

--- a/mars/xlog/export_include/xlogger/xlogger.h
+++ b/mars/xlog/export_include/xlogger/xlogger.h
@@ -84,7 +84,9 @@ class XMessage {
 #endif
     XMessage&
     WriteNoFormat(const char* _log) {
-        m_message += _log;
+        if (_log) {
+            m_message += _log;
+        }
         return *this;
     }
 #ifdef __GNUC__
@@ -92,7 +94,9 @@ class XMessage {
 #endif
     XMessage&
     WriteNoFormat(const TypeSafeFormat&, const char* _log) {
-        m_message += _log;
+        if (_log) {
+            m_message += _log;
+        }
         return *this;
     }
 
@@ -204,7 +208,9 @@ class XLogger {
 #endif
     XLogger&
     WriteNoFormat(const char* _log) {
-        m_message += _log;
+        if (_log) {
+            m_message += _log;
+        }
         return *this;
     }
 #ifdef __GNUC__
@@ -212,7 +218,9 @@ class XLogger {
 #endif
     XLogger&
     WriteNoFormat(const TypeSafeFormat&, const char* _log) {
-        m_message += _log;
+        if (_log) {
+            m_message += _log;
+        }
         return *this;
     }
 


### PR DESCRIPTION
增加null检查，否则在转换为utf8失败时可能会导致WriteNoFormat会有NULL传入，引起crash