### PR TITLE
fix: fix get length of KStringKeepAliveTimeout

### DIFF
--- a/mars/comm/http.cc
+++ b/mars/comm/http.cc
@@ -419,10 +419,11 @@ uint32_t HeaderFields::KeepAliveTimeout() const {
     std::vector<std::string> tokens;
     strutil::SplitToken(aliveConfig, ",", tokens);
     auto iter = tokens.begin();
+    size_t timeout_token_len = strlen(KStringKeepAliveTimeout);
     while (iter != tokens.end()) {
         size_t pos = iter->find(KStringKeepAliveTimeout);
         if (pos != std::string::npos) {
-            const char* value = iter->c_str() + sizeof(KStringKeepAliveTimeout);
+            const char* value = iter->c_str() + timeout_token_len;
             int timeout = (int)strtol(value, NULL, 10);
             if (timeout > 0 && timeout < 60)
                 return (uint32_t)timeout;


### PR DESCRIPTION
Fix the retrieval of KStringKeepAliveTimeout string length, otherwise it will cause issues on 32-bit systems. The reason it works fine on 64-bit systems is that the string length happens to be 8, which is also the size of a pointer.