### PR TITLE
Fix: Potential Vulnerability in Cloned Function

### DIFF
--- a/mars/comm/windows/zlib/inftrees.c
+++ b/mars/comm/windows/zlib/inftrees.c
@@ -54,7 +54,7 @@ unsigned short FAR *work;
     code FAR *next;             /* next available space in table */
     const unsigned short FAR *base;     /* base value table to use */
     const unsigned short FAR *extra;    /* extra bits table to use */
-    int end;                    /* use base and extra for symbol > end */
+    unsigned match;             /* use base and extra for symbol >= match */
     unsigned short count[MAXBITS+1];    /* number of codes of each length */
     unsigned short offs[MAXBITS+1];     /* offsets in table for each length */
     static const unsigned short lbase[31] = { /* Length codes 257..285 base */
@@ -181,19 +181,17 @@ unsigned short FAR *work;
     switch (type) {
     case CODES:
         base = extra = work;    /* dummy value--not used */
-        end = 19;
+        match = 20;
         break;
     case LENS:
         base = lbase;
-        base -= 257;
         extra = lext;
-        extra -= 257;
-        end = 256;
+        match = 257;
         break;
     default:            /* DISTS */
         base = dbase;
         extra = dext;
-        end = -1;
+        match = 0;
     }
 
     /* initialize state for loop */
@@ -216,13 +214,13 @@ unsigned short FAR *work;
     for (;;) {
         /* create table entry */
         here.bits = (unsigned char)(len - drop);
-        if ((int)(work[sym]) < end) {
+        if (work[sym] + 1 < match) {
             here.op = (unsigned char)0;
             here.val = work[sym];
         }
-        else if ((int)(work[sym]) > end) {
-            here.op = (unsigned char)(extra[work[sym]]);
-            here.val = base[work[sym]];
+        else if (work[sym] >= match) {
+            here.op = (unsigned char)(extra[work[sym] - match]);
+            here.val = base[work[sym] - match];
         }
         else {
             here.op = (unsigned char)(32 + 64);         /* end of block */


### PR DESCRIPTION
**Description**
This PR fixes a security vulnerability in inflate_table() that was cloned from zlib but did not receive the security patch. The original issue was reported and fixed under https://github.com/madler/zlib/commit/6a043145ca6e9c55184013841a67b2fef87e44c0.
This PR applies the same patch to eliminate the vulnerability.

**References**
https://nvd.nist.gov/vuln/detail/CVE-2016-9840
https://github.com/madler/zlib/commit/6a043145ca6e9c55184013841a67b2fef87e44c0

P.S: Sorry for the duplicated requests