### PR TITLE
bugfix(xlog) : Fixed compilation error if XLOG_NO_CRYPT macro was enabled

### DIFF
--- a/mars/xlog/crypt/log_crypt.cc
+++ b/mars/xlog/crypt/log_crypt.cc
@@ -41,6 +41,7 @@ namespace xlog {
 
 const static int TEA_BLOCK_LEN = 8;
 
+#ifndef XLOG_NO_CRYPT
 static void __TeaEncrypt(uint32_t* v, uint32_t* k) {
     uint32_t v0 = v[0], v1 = v[1], sum = 0, i;
     const static uint32_t delta = 0x9e3779b9;
@@ -53,6 +54,7 @@ static void __TeaEncrypt(uint32_t* v, uint32_t* k) {
     v[0] = v0;
     v[1] = v1;
 }
+#endif
 
 static uint16_t __GetSeq(bool _is_async) {
     if (!_is_async) {


### PR DESCRIPTION
<img width="1061" alt="Screenshot 2025-03-07 at 4 34 55 PM" src="https://github.com/user-attachments/assets/f52ea131-6585-4124-803b-242d71de486c" />

Added macro checks for **__TeaEncrypt** to fix this compile error when ** XLOG_NO_CRYPT** is enabled