### PR TITLE
Fix:Use_snprintf_instead_of_sprintf_to_prevent_buffer_overflow

### DIFF
--- a/mars/comm/android/getprocessname.c
+++ b/mars/comm/android/getprocessname.c
@@ -20,7 +20,7 @@ const char* getprocessname() {
     if (x)
         return x;
 
-    sprintf(data, "/proc/%d/cmdline", getpid());
+    snprintf(data, sizeof(data), "/proc/%d/cmdline", getpid());
     fp = fopen(data, "r");
     if (fp) {
         x = fgets(data, 1024, fp);


### PR DESCRIPTION
This pull request resolves a critical security vulnerability in the getprocessname.c file. The existing code used the sprintf unction, which is known to be unsafe and can lead to buffer overflows.

The fix replaces the sprintf call with snprintf, a safer alternative that prevents buffer overflows by allowing the maximum number of bytes to be written to the buffer to be specified.

This change improves the security and stability of the application.

Changes:
 Replaced sprintf with snprintf in mars/comm/android/getprocessname.c